### PR TITLE
Better Serializer support + disabled Symfony serializer

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# Permissions
-GROUP_ID=1000
-USER_ID=1000

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/.env
+.env
 /cache
 /vendor
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /cache
 /vendor
 .idea
+/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ branches:
     only: master
 
 install:
-    - phpenv config-rm xdebug.ini
+    - pecl install apcu-5.1.8
+    - phpenv config-rm xdebug.ini; fi
     - phpenv config-add docker/php/config/php.ini
-    - phpenv config-add docker/php/config/apcu.ini
     - composer self-update
     - composer install --prefer-source --optimize-autoloader
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 install:
     - phpenv config-rm xdebug.ini
     - phpenv config-add docker/php/config/php.ini
+    - php -i
     - composer self-update
     - composer install --prefer-source --optimize-autoloader
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: php
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
-    - hhvm
 
 branches:
     only: master
 
 install:
-    - if [[ $TRAVIS_PHP_VERSION = 5.6 ]]; then printf "\n" | pecl install apcu-4.0.11; fi
     - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu; fi
     - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
-    - if [[ $TRAVIS_PHP_VERSION = 'hhvm' ]]; then mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d; fi
     - phpenv config-add docker/php/config/php.ini
     - composer self-update
     - composer install --prefer-source --optimize-autoloader

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 install:
     - phpenv config-rm xdebug.ini
     - phpenv config-add docker/php/config/php.ini
-    - php -i
+    - phpenv config-add docker/php/config/apcu.ini
     - composer self-update
     - composer install --prefer-source --optimize-autoloader
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     only: master
 
 install:
-    - pecl install apcu-5.1.8
+    - pecl install -f apcu-5.1.8
     - phpenv config-rm xdebug.ini; fi
     - phpenv config-add docker/php/config/php.ini
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 
 install:
     - printf "\n" | pecl install -f apcu-5.1.8
-    - phpenv config-rm xdebug.ini; fi
+    - phpenv config-rm xdebug.ini
     - phpenv config-add docker/php/config/php.ini
     - composer self-update
     - composer install --prefer-source --optimize-autoloader

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     only: master
 
 install:
-    - printf "\n" | pecl install -f apcu-5.1.8
+    - printf "\n" | pecl install -f apcu
     - phpenv config-rm xdebug.ini
     - phpenv config-add docker/php/config/php.ini
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,9 @@ script:
     - bin/benchmark --vertical-complexity 4 --iteration 100
     - bin/benchmark --horizontal-complexity 4 --vertical-complexity 4 --iteration 100
     - bin/benchmark --horizontal-complexity 20 --vertical-complexity 100 --iteration 100
+    - bin/phpbench run src/SerializerBenchmarks/JmsSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=a.xml
+    - bin/phpbench run src/SerializerBenchmarks/IvorySerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=b.xml
+    - bin/phpbench run src/SerializerBenchmarks/BetterSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=c.xml
+    - bin/phpbench run src/SerializerBenchmarks/SymfonyGsNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=d.xml
+    - bin/phpbench run src/SerializerBenchmarks/SymfonyObjNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=e.xml
+    - bin/phpbench report --file=a.xml --file=b.xml --file=c.xml --file=d.xml --file=e.xml --report=compare

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
     - bin/benchmark --horizontal-complexity 4 --iteration 100
     - bin/benchmark --vertical-complexity 4 --iteration 100
     - bin/benchmark --horizontal-complexity 4 --vertical-complexity 4 --iteration 100
+    - bin/benchmark --horizontal-complexity 20 --vertical-complexity 100 --iteration 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     only: master
 
 install:
-    - pecl install -f apcu-5.1.8
+    - printf "\n" | pecl install -f apcu-5.1.8
     - phpenv config-rm xdebug.ini; fi
     - phpenv config-add docker/php/config/php.ini
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ script:
     - bin/benchmark --vertical-complexity 4 --iteration 100
     - bin/benchmark --horizontal-complexity 4 --vertical-complexity 4 --iteration 100
     - bin/benchmark --horizontal-complexity 20 --vertical-complexity 100 --iteration 100
-    - bin/phpbench run src/SerializerBenchmarks/JmsSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=a.xml
-    - bin/phpbench run src/SerializerBenchmarks/IvorySerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=b.xml
-    - bin/phpbench run src/SerializerBenchmarks/BetterSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=c.xml
-    - bin/phpbench run src/SerializerBenchmarks/SymfonyGsNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=d.xml
-    - bin/phpbench run src/SerializerBenchmarks/SymfonyObjNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=e.xml
-    - bin/phpbench report --file=a.xml --file=b.xml --file=c.xml --file=d.xml --file=e.xml --report=compare
+    - vendor/bin/phpbench run src/SerializerBenchmarks/JmsSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=a.xml
+    - vendor/bin/phpbench run src/SerializerBenchmarks/IvorySerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=b.xml
+    - vendor/bin/phpbench run src/SerializerBenchmarks/BetterSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=c.xml
+    - vendor/bin/phpbench run src/SerializerBenchmarks/SymfonyGsNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=d.xml
+    - vendor/bin/phpbench run src/SerializerBenchmarks/SymfonyObjNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=e.xml
+    - vendor/bin/phpbench report --file=a.xml --file=b.xml --file=c.xml --file=d.xml --file=e.xml --report=compare

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
     only: master
 
 install:
-    - pecl install apcu
     - phpenv config-rm xdebug.ini
     - phpenv config-add docker/php/config/php.ini
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ branches:
     only: master
 
 install:
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu; fi
-    - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
+    - pecl install apcu
+    - phpenv config-rm xdebug.ini
     - phpenv config-add docker/php/config/php.ini
     - composer self-update
     - composer install --prefer-source --optimize-autoloader

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ If you'd like to benchmark also the Symfony serializer, you can use the `with-sy
 $ docker-compose run --rm php bin/benchmark --with-symfony-serializer
 ```
 
+## PhpBench integration
+
+All the benchmarks were also integrated with PhpBench, to provide more trustful results. You can run the benchmarks
+using these commands:
+
+```bash
+$ vendor/bin/phpbench run src/SerializerBenchmarks/JmsSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=a.xml
+$ vendor/bin/phpbench run src/SerializerBenchmarks/IvorySerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=b.xml
+$ vendor/bin/phpbench run src/SerializerBenchmarks/BetterSerializerBench.php --report=aggregate --revs=10 --iterations=10 --retry-threshold=5 --dump-file=c.xml
+$ vendor/bin/phpbench run src/SerializerBenchmarks/SymfonyGsNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=d.xml
+$ vendor/bin/phpbench run src/SerializerBenchmarks/SymfonyObjNormSerializerBench.php --report=aggregate --revs=1 --iterations=1  --dump-file=e.xml
+$ vendor/bin/phpbench report --file=a.xml --file=b.xml --file=c.xml --file=d.xml --file=e.xml --report=compare
+```
+
 ## Contribute
 
 We love contributors! Ivory is an open source project. If you'd like to contribute, feel free to propose a PR!.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ which represents a complexity factor:
 $ docker-compose run --rm php bin/benchmark --vertical-complexity 4
 ```
 
+Symfony serializer isn't included in the benchmarking process by default, because it is very slow.
+If you'd like to benchmark also the Symfony serializer, you can use the `with-symfony-serializer` option:
+
+``` bash
+$ docker-compose run --rm php bin/benchmark --with-symfony-serializer
+```
+
 ## Contribute
 
 We love contributors! Ivory is an open source project. If you'd like to contribute, feel free to propose a PR!.

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,17 @@
 {
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.1",
         "doctrine/cache": "^1.0",
         "egeloen/serializer": "^1.0",
-        "jms/serializer": "^1.0",
+        "jms/serializer": "^1.8",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/cache": "^3.0",
         "symfony/console": "^3.0",
         "symfony/property-access": "^3.0",
         "symfony/serializer": "^3.0",
-        "symfony/yaml": "^3.0"
+        "symfony/yaml": "^3.0",
+        "pimple/pimple": "~3.0",
+        "better-serializer/better-serializer": "dev-master"
     },
     "autoload": {
         "psr-4": { "Ivory\\Tests\\Serializer\\Benchmark\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "php": "^7.1",
         "doctrine/cache": "^1.0",
         "egeloen/serializer": "^1.0",
-        "jms/serializer": "^1.8",
+        "jms/serializer": "^1.12",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/cache": "^3.0",
         "symfony/console": "^3.0",
@@ -11,8 +11,8 @@
         "symfony/serializer": "^3.0",
         "symfony/yaml": "^3.0",
         "pimple/pimple": "~3.0",
-        "better-serializer/better-serializer": "dev-master#8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740",
-        "phpbench/phpbench": "^1.0@dev"
+        "phpbench/phpbench": "^1.0@dev",
+        "better-serializer/better-serializer": "^0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/serializer": "^3.0",
         "symfony/yaml": "^3.0",
         "pimple/pimple": "~3.0",
-        "better-serializer/better-serializer": "dev-master",
+        "better-serializer/better-serializer": "dev-master#8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740",
         "phpbench/phpbench": "^1.0@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,14 @@
         "symfony/serializer": "^3.0",
         "symfony/yaml": "^3.0",
         "pimple/pimple": "~3.0",
-        "better-serializer/better-serializer": "dev-master"
+        "better-serializer/better-serializer": "dev-master",
+        "phpbench/phpbench": "^1.0@dev"
     },
     "autoload": {
-        "psr-4": { "Ivory\\Tests\\Serializer\\Benchmark\\": "src/" }
+        "psr-4": {
+            "Ivory\\Tests\\Serializer\\Benchmark\\": "src/",
+            "SerializerBenchmarks\\": "src/SerializerBenchmarks/"
+        }
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "symfony/cache": "^3.0",
         "symfony/console": "^3.0",
         "symfony/property-access": "^3.0",
-        "symfony/serializer": "^3.0",
         "symfony/yaml": "^3.0",
         "pimple/pimple": "~3.0",
         "phpbench/phpbench": "^1.0@dev",
-        "better-serializer/better-serializer": "^0.1"
+        "better-serializer/better-serializer": "^0.1",
+        "symfony/serializer": "^v4.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b2dc7983c97ee3cfee6413ce6446d0",
+    "content-hash": "290877dd39af63389425c290cc6af3c6",
     "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2017-05-04T02:00:24+00:00"
+        },
         {
             "name": "better-serializer/better-serializer",
             "version": "dev-master",
@@ -64,6 +119,37 @@
             ],
             "description": "General de/serializer for vatious serialization formats.",
             "time": "2017-09-08 19:46:16"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -645,6 +731,142 @@
             "time": "2017-09-04 09:35:39"
         },
         {
+            "name": "lstrojny/functional-php",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lstrojny/functional-php.git",
+                "reference": "c0c15f048355d0a7ab17914022ec1f901fe5144a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lstrojny/functional-php/zipball/c0c15f048355d0a7ab17914022ec1f901fe5144a",
+                "reference": "c0c15f048355d0a7ab17914022ec1f901fe5144a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Functional\\": "src/Functional"
+                },
+                "files": [
+                    "src/Functional/Average.php",
+                    "src/Functional/Capture.php",
+                    "src/Functional/ConstFunction.php",
+                    "src/Functional/CompareOn.php",
+                    "src/Functional/CompareObjectHashOn.php",
+                    "src/Functional/Compose.php",
+                    "src/Functional/Concat.php",
+                    "src/Functional/Contains.php",
+                    "src/Functional/Curry.php",
+                    "src/Functional/CurryN.php",
+                    "src/Functional/Difference.php",
+                    "src/Functional/DropFirst.php",
+                    "src/Functional/DropLast.php",
+                    "src/Functional/Each.php",
+                    "src/Functional/Equal.php",
+                    "src/Functional/ErrorToException.php",
+                    "src/Functional/Every.php",
+                    "src/Functional/False.php",
+                    "src/Functional/Falsy.php",
+                    "src/Functional/Filter.php",
+                    "src/Functional/First.php",
+                    "src/Functional/FirstIndexOf.php",
+                    "src/Functional/FlatMap.php",
+                    "src/Functional/Flatten.php",
+                    "src/Functional/Flip.php",
+                    "src/Functional/GreaterThan.php",
+                    "src/Functional/GreaterThanOrEqual.php",
+                    "src/Functional/Group.php",
+                    "src/Functional/Head.php",
+                    "src/Functional/Id.php",
+                    "src/Functional/IfElse.php",
+                    "src/Functional/Identical.php",
+                    "src/Functional/IndexesOf.php",
+                    "src/Functional/Intersperse.php",
+                    "src/Functional/Invoke.php",
+                    "src/Functional/InvokeFirst.php",
+                    "src/Functional/InvokeIf.php",
+                    "src/Functional/InvokeLast.php",
+                    "src/Functional/Invoker.php",
+                    "src/Functional/Last.php",
+                    "src/Functional/LastIndexOf.php",
+                    "src/Functional/LessThan.php",
+                    "src/Functional/LessThanOrEqual.php",
+                    "src/Functional/LexicographicCompare.php",
+                    "src/Functional/Map.php",
+                    "src/Functional/Match.php",
+                    "src/Functional/Maximum.php",
+                    "src/Functional/Memoize.php",
+                    "src/Functional/Minimum.php",
+                    "src/Functional/None.php",
+                    "src/Functional/Not.php",
+                    "src/Functional/PartialAny.php",
+                    "src/Functional/PartialLeft.php",
+                    "src/Functional/PartialMethod.php",
+                    "src/Functional/PartialRight.php",
+                    "src/Functional/Partition.php",
+                    "src/Functional/Pick.php",
+                    "src/Functional/Pluck.php",
+                    "src/Functional/Poll.php",
+                    "src/Functional/Product.php",
+                    "src/Functional/Ratio.php",
+                    "src/Functional/ReduceLeft.php",
+                    "src/Functional/ReduceRight.php",
+                    "src/Functional/Reindex.php",
+                    "src/Functional/Reject.php",
+                    "src/Functional/Retry.php",
+                    "src/Functional/Select.php",
+                    "src/Functional/SequenceConstant.php",
+                    "src/Functional/SequenceExponential.php",
+                    "src/Functional/SequenceLinear.php",
+                    "src/Functional/Some.php",
+                    "src/Functional/Sort.php",
+                    "src/Functional/Sum.php",
+                    "src/Functional/SuppressError.php",
+                    "src/Functional/Tail.php",
+                    "src/Functional/TailRecursion.php",
+                    "src/Functional/True.php",
+                    "src/Functional/Truthy.php",
+                    "src/Functional/Unique.php",
+                    "src/Functional/With.php",
+                    "src/Functional/Zip.php",
+                    "src/Functional/ZipAll.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Strojny",
+                    "email": "lstrojny@php.net",
+                    "homepage": "http://usrportage.de"
+                },
+                {
+                    "name": "Max Beutel",
+                    "email": "nash12@gmail.com"
+                }
+            ],
+            "description": "Functional primitives for PHP",
+            "keywords": [
+                "functional"
+            ],
+            "time": "2017-05-08T10:17:44+00:00"
+        },
+        {
             "name": "marc-mabe/php-enum",
             "version": "2.x-dev",
             "source": {
@@ -754,6 +976,161 @@
                 "random"
             ],
             "time": "2017-03-13T16:27:32+00:00"
+        },
+        {
+            "name": "phpbench/container",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/container.git",
+                "reference": "8cd29cf58104e68b4d5cc2af5703e6235e41e7b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/container/zipball/8cd29cf58104e68b4d5cc2af5703e6235e41e7b9",
+                "reference": "8cd29cf58104e68b4d5cc2af5703e6235e41e7b9",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\DependencyInjection\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Simple, configurable, service container.",
+            "time": "2017-07-18T12:10:10+00:00"
+        },
+        {
+            "name": "phpbench/dom",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/dom.git",
+                "reference": "b135378dd0004c05ba5446aeddaf0b83339c1c4c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/dom/zipball/b135378dd0004c05ba5446aeddaf0b83339c1c4c",
+                "reference": "b135378dd0004c05ba5446aeddaf0b83339c1c4c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^5.4|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\Dom\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "DOM wrapper to simplify working with the PHP DOM implementation",
+            "time": "2016-02-27T12:15:56+00:00"
+        },
+        {
+            "name": "phpbench/phpbench",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/phpbench.git",
+                "reference": "5869bd69f217015a2d62757dcac46c62ef417269"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/5869bd69f217015a2d62757dcac46c62ef417269",
+                "reference": "5869bd69f217015a2d62757dcac46c62ef417269",
+                "shasum": ""
+            },
+            "require": {
+                "beberlei/assert": "^2.4",
+                "doctrine/annotations": "^1.2.7",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "lstrojny/functional-php": "1.0|^1.2.3",
+                "php": "^7.0",
+                "phpbench/container": "~1.0",
+                "phpbench/dom": "~0.2.0",
+                "seld/jsonlint": "^1.0",
+                "symfony/console": "^2.6|^3.0|^4.0",
+                "symfony/debug": "^2.4|^3.0|^4.0",
+                "symfony/filesystem": "^2.4|^3.0|^4.0",
+                "symfony/finder": "^2.4|^3.0|^4.0",
+                "symfony/options-resolver": "^2.6|^3.0|^4.0",
+                "symfony/process": "^2.1|^3.0|^4.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.4",
+                "liip/rmt": "^1.2",
+                "padraic/phar-updater": "^1.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "bin": [
+                "bin/phpbench"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\": "lib/",
+                    "PhpBench\\Extensions\\Dbal\\": "extensions/dbal/lib/",
+                    "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "PHP Benchmarking Framework",
+            "time": "2017-07-27 14:50:30"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -1377,6 +1754,55 @@
             "time": "2017-08-17T12:55:16+00:00"
         },
         {
+            "name": "seld/jsonlint",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
+                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "time": "2017-06-18T15:11:04+00:00"
+        },
+        {
             "name": "symfony/cache",
             "version": "3.4.x-dev",
             "source": {
@@ -1570,6 +1996,104 @@
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
             "time": "2017-09-03 14:49:52"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "df8e441d071093d215272c459581b06e17e1783e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/df8e441d071093d215272c459581b06e17e1783e",
+                "reference": "df8e441d071093d215272c459581b06e17e1783e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-08-02 05:32:45"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "d04fb01c1aa6e3f2f62e5505b62ede74f7cd4d1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/d04fb01c1aa6e3f2f62e5505b62ede74f7cd4d1a",
+                "reference": "d04fb01c1aa6e3f2f62e5505b62ede74f7cd4d1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-06-01 22:17:54"
         },
         {
             "name": "symfony/inflector",
@@ -1854,6 +2378,55 @@
             "time": "2017-06-14 15:44:48"
         },
         {
+            "name": "symfony/process",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "2750e6512a31bea2bcbd088a7e231cb4192e99da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2750e6512a31bea2bcbd088a7e231cb4192e99da",
+                "reference": "2750e6512a31bea2bcbd088a7e231cb4192e99da",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-07-12 14:12:10"
+        },
+        {
             "name": "symfony/property-access",
             "version": "3.4.x-dev",
             "source": {
@@ -2111,7 +2684,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "better-serializer/better-serializer": 20
+        "better-serializer/better-serializer": 20,
+        "phpbench/phpbench": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d1943a10d99530cd524c0b79d8127c8",
+    "content-hash": "3b5f3e14c5402c8b6e6fab1b47fbad14",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2146,6 +2146,64 @@
             "time": "2017-10-11T12:05:26+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "9d31bef82d2e9b033f335d60b96611757f98c605"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/9d31bef82d2e9b033f335d60b96611757f98c605",
+                "reference": "9d31bef82d2e9b033f335d60b96611757f98c605",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-05-17T18:32:56+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "dev-master",
             "source": {
@@ -2382,38 +2440,40 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "3.4.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "7a392ecf139e786a13cb894a5c6338aedada771f"
+                "reference": "2cd0f38962526c1b58ecb9454cc377140d44d596"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/7a392ecf139e786a13cb894a5c6338aedada771f",
-                "reference": "7a392ecf139e786a13cb894a5c6338aedada771f",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/2cd0f38962526c1b58ecb9454cc377140d44d596",
+                "reference": "2cd0f38962526c1b58ecb9454cc377140d44d596",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "phpdocumentor/type-resolver": "<0.2.1",
-                "symfony/dependency-injection": "<3.2",
-                "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
-                "symfony/property-info": "<3.1",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/property-access": "<3.4",
+                "symfony/property-info": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-                "symfony/cache": "~3.1|~4.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.2|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0",
-                "symfony/property-info": "~3.1|~4.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/property-info": "~3.4|~4.0",
+                "symfony/validator": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -2429,7 +2489,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2456,7 +2516,7 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-02T15:47:46+00:00"
+            "time": "2018-05-31T10:18:23+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8f247210577c16221cabebc4a63f6d0",
+    "content-hash": "8d1943a10d99530cd524c0b79d8127c8",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -63,43 +63,43 @@
         },
         {
             "name": "better-serializer/better-serializer",
-            "version": "dev-master",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/better-serializer/better-serializer.git",
-                "reference": "8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740"
+                "reference": "9ed5f4b8143d6896cb3b3744dce52f2d3ab3686d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740",
-                "reference": "8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740",
+                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/9ed5f4b8143d6896cb3b3744dce52f2d3ab3686d",
+                "reference": "9ed5f4b8143d6896cb3b3744dce52f2d3ab3686d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "^1.3",
                 "doctrine/cache": "^v1.7",
                 "doctrine/instantiator": "^1.0",
-                "infection/infection": "^0.7",
                 "league/flysystem": "^1.0",
                 "marc-mabe/php-enum": "^2.3",
-                "php": "^7.1",
-                "phpdocumentor/reflection-docblock": "^3.0",
+                "php": "^7.2",
+                "phpdocumentor/reflection-docblock": "^4.3",
                 "pimple/pimple": "^3.0"
             },
             "require-dev": {
                 "doctrine/collections": "^1.5",
                 "friendsofphp/php-cs-fixer": "^2.5",
+                "infection/infection": "^0.8",
                 "jakub-onderka/php-parallel-lint": "^0.9.2",
                 "jms/serializer": "^1.8",
                 "nikic/php-parser": "^3.0",
                 "phpmd/phpmd": "^2.6",
-                "phpro/grumphp": "^v0.12",
+                "phpro/grumphp": "^v0.14",
                 "phpstan/phpstan": "^0.7",
-                "phpunit/phpunit": "^6.0",
+                "phpunit/phpunit": "^7.1",
                 "satooshi/php-coveralls": "~1.0",
-                "sebastian/phpcpd": "^3.0",
+                "sebastian/phpcpd": "^4.0",
                 "sensiolabs/security-checker": "^4.0",
-                "squizlabs/php_codesniffer": "^3.0",
+                "squizlabs/php_codesniffer": "^3.2",
                 "symfony/var-dumper": "^v3.2"
             },
             "type": "library",
@@ -119,63 +119,7 @@
                 }
             ],
             "description": "General de/serializer for vatious serialization formats.",
-            "time": "2018-01-03T20:12:15+00:00"
-        },
-        {
-            "name": "composer/ca-bundle",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "134242fce6195119baf9ae553984e96ff888c2c5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/134242fce6195119baf9ae553984e96ff888c2c5",
-                "reference": "134242fce6195119baf9ae553984e96ff888c2c5",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2017-12-17T13:07:26+00:00"
+            "time": "2018-05-27T21:47:06+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -210,16 +154,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "dev-master",
+            "version": "1.7.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "fe71864318b4912198a317783392c639221ec2fd"
+                "reference": "232c5da3903f788e02328b4e8486eceea0c76e58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/fe71864318b4912198a317783392c639221ec2fd",
-                "reference": "fe71864318b4912198a317783392c639221ec2fd",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/232c5da3903f788e02328b4e8486eceea0c76e58",
+                "reference": "232c5da3903f788e02328b4e8486eceea0c76e58",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +172,7 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -274,7 +218,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-12-24T17:33:14+00:00"
+            "time": "2018-05-06T10:14:50+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -358,21 +302,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8520afa0d55f9b3aba1070a9bf65d4b0d9fb7727"
+                "reference": "870a62d7b0d63d4e0ffa8f2ce3ab7c8a53d1846d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8520afa0d55f9b3aba1070a9bf65d4b0d9fb7727",
-                "reference": "8520afa0d55f9b3aba1070a9bf65d4b0d9fb7727",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/870a62d7b0d63d4e0ffa8f2ce3ab7c8a53d1846d",
+                "reference": "870a62d7b0d63d4e0ffa8f2ce3ab7c8a53d1846d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
+                "doctrine/coding-standard": "^4.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-shim": "^0.9.2",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -402,7 +349,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-12-22T05:44:00+00:00"
+            "time": "2018-03-05T09:41:42+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -410,16 +357,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "cc709ba91eee09540091ad5a5f2616727662e41b"
+                "reference": "c0970c7889bfd33504c4fa54f35451c27897381d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/cc709ba91eee09540091ad5a5f2616727662e41b",
-                "reference": "cc709ba91eee09540091ad5a5f2616727662e41b",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c0970c7889bfd33504c4fa54f35451c27897381d",
+                "reference": "c0970c7889bfd33504c4fa54f35451c27897381d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
             },
             "type": "library",
             "extra": {
@@ -456,7 +406,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2017-07-24T09:37:08+00:00"
+            "time": "2018-05-14T15:49:16+00:00"
         },
         {
             "name": "egeloen/serializer",
@@ -532,66 +482,6 @@
                 "serializer"
             ],
             "time": "2017-02-27T21:35:23+00:00"
-        },
-        {
-            "name": "infection/infection",
-            "version": "0.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/infection/infection.git",
-                "reference": "6c237470a268196f82df70179d1a57d0e6cdfa57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/6c237470a268196f82df70179d1a57d0e6cdfa57",
-                "reference": "6c237470a268196f82df70179d1a57d0e6cdfa57",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^3.0",
-                "padraic/phar-updater": "^1.0.4",
-                "php": "^7.0",
-                "pimple/pimple": "^3.0",
-                "sebastian/diff": "^1.4|^2.0",
-                "symfony/console": "^3.2 || ^4.0",
-                "symfony/finder": "^3.2 || ^4.0",
-                "symfony/process": "^3.2 || ^4.0",
-                "symfony/yaml": "^3.2 || ^4.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.1"
-            },
-            "bin": [
-                "bin/infection"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Infection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Maks Rafalko",
-                    "email": "maks.rafalko@gmail.com",
-                    "homepage": "https://twitter.com/maks_rafalko"
-                }
-            ],
-            "description": "Infection is a Mutation Testing framework for PHP. The mutation adequacy score can be used to measure the effectiveness of a test set in terms of its ability to detect faults.",
-            "keywords": [
-                "coverage",
-                "mutant",
-                "mutation framework",
-                "mutation testing",
-                "testing",
-                "unit testing"
-            ],
-            "time": "2017-12-22T23:03:31+00:00"
         },
         {
             "name": "jms/metadata",
@@ -681,16 +571,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "dev-master",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "62c7ff6d61f8692eac8be024c542b3d9d0ab8c8a"
+                "reference": "1ea5e0ba68b6b38c327eb3adf5888ac74b587e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/62c7ff6d61f8692eac8be024c542b3d9d0ab8c8a",
-                "reference": "62c7ff6d61f8692eac8be024c542b3d9d0ab8c8a",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/1ea5e0ba68b6b38c327eb3adf5888ac74b587e9c",
+                "reference": "1ea5e0ba68b6b38c327eb3adf5888ac74b587e9c",
                 "shasum": ""
             },
             "require": {
@@ -698,12 +588,11 @@
                 "doctrine/instantiator": "^1.0.3",
                 "jms/metadata": "~1.1",
                 "jms/parser-lib": "1.*",
-                "php": ">=5.5.0",
+                "php": "^5.5|^7.0",
                 "phpcollection/phpcollection": "~0.1",
                 "phpoption/phpoption": "^1.1"
             },
             "conflict": {
-                "jms/serializer-bundle": "<1.2.1",
                 "twig/twig": "<1.12"
             },
             "require-dev": {
@@ -731,7 +620,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10-dev"
+                    "dev-1.x": "1.11-dev"
                 }
             },
             "autoload": {
@@ -741,7 +630,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache-2.0"
+                "MIT"
             ],
             "authors": [
                 {
@@ -762,7 +651,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-11-30T18:23:40+00:00"
+            "time": "2018-05-25T17:01:33+00:00"
         },
         {
             "name": "league/flysystem",
@@ -770,12 +659,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "c847ed51212861d746a4c3eed7632b07328a926f"
+                "reference": "6a73c6922a52495caa0d59cc214e8e10ac930af3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/c847ed51212861d746a4c3eed7632b07328a926f",
-                "reference": "c847ed51212861d746a4c3eed7632b07328a926f",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/6a73c6922a52495caa0d59cc214e8e10ac930af3",
+                "reference": "6a73c6922a52495caa0d59cc214e8e10ac930af3",
                 "shasum": ""
             },
             "require": {
@@ -846,7 +735,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-01-01T13:00:16+00:00"
+            "time": "2018-05-24T08:51:26+00:00"
         },
         {
             "name": "lstrojny/functional-php",
@@ -1046,177 +935,6 @@
                 "typehint"
             ],
             "time": "2017-07-02T11:49:04+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "3.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/579f4ce846734a1cf55d6a531d00ca07a43e3cda",
-                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "time": "2017-12-26T14:43:21+00:00"
-        },
-        {
-            "name": "padraic/humbug_get_contents",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/humbug/file_get_contents.git",
-                "reference": "6e6c47af83cb98c610f4ba7d06ee809ad59ede1b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/humbug/file_get_contents/zipball/6e6c47af83cb98c610f4ba7d06ee809ad59ede1b",
-                "reference": "6e6c47af83cb98c610f4ba7d06ee809ad59ede1b",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "ext-openssl": "*",
-                "php": "^5.3 || ^7.0"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.1",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": false
-                },
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Humbug\\": "src/"
-                },
-                "files": [
-                    "src/function.php",
-                    "src/functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
-                },
-                {
-                    "name": "Théo Fidry",
-                    "email": "theo.fidry@gmail.com"
-                }
-            ],
-            "description": "Secure wrapper for accessing HTTPS resources with file_get_contents for PHP 5.3+",
-            "homepage": "https://github.com/padraic/file_get_contents",
-            "keywords": [
-                "download",
-                "file_get_contents",
-                "http",
-                "https",
-                "ssl",
-                "tls"
-            ],
-            "time": "2017-07-10T10:32:34+00:00"
-        },
-        {
-            "name": "padraic/phar-updater",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/humbug/phar-updater.git",
-                "reference": "e5a5da3dc3344031271157c7f10b0fa04afffa9b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/humbug/phar-updater/zipball/e5a5da3dc3344031271157c7f10b0fa04afffa9b",
-                "reference": "e5a5da3dc3344031271157c7f10b0fa04afffa9b",
-                "shasum": ""
-            },
-            "require": {
-                "padraic/humbug_get_contents": "^1.0",
-                "php": "^5.6|^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.5|^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Humbug\\SelfUpdate\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
-                }
-            ],
-            "description": "A thing to make PHAR self-updating easy and secure.",
-            "keywords": [
-                "humbug",
-                "phar",
-                "self-update",
-                "update"
-            ],
-            "time": "2017-11-01T16:56:56+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1478,7 +1196,7 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "dev-master",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
@@ -1532,29 +1250,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -1573,7 +1297,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1913,58 +1637,6 @@
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "0fd4d14dd707808a95ca67ada62c15f9a9186b15"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/0fd4d14dd707808a95ca67ada62c15f9a9186b15",
-                "reference": "0fd4d14dd707808a95ca67ada62c15f9a9186b15",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2017-12-14T13:13:00+00:00"
-        },
-        {
             "name": "seld/jsonlint",
             "version": "1.7.0",
             "source": {
@@ -2263,12 +1935,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "db4ab92faa7b893bd96e6a2e29251ff8bd2a904d"
+                "reference": "c1f37edd31fc56312f5912e4322b2a16f5e12ef3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/db4ab92faa7b893bd96e6a2e29251ff8bd2a904d",
-                "reference": "db4ab92faa7b893bd96e6a2e29251ff8bd2a904d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/c1f37edd31fc56312f5912e4322b2a16f5e12ef3",
+                "reference": "c1f37edd31fc56312f5912e4322b2a16f5e12ef3",
                 "shasum": ""
             },
             "require": {
@@ -2277,7 +1949,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2304,7 +1976,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:38:11+00:00"
+            "time": "2018-05-16T14:42:13+00:00"
         },
         {
             "name": "symfony/inflector",
@@ -2597,12 +2269,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "437ffa07721b8441c9acfa3c749485dffbaae09e"
+                "reference": "4f10286a128df6b60b3706752e11f6227fcac844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/437ffa07721b8441c9acfa3c749485dffbaae09e",
-                "reference": "437ffa07721b8441c9acfa3c749485dffbaae09e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/4f10286a128df6b60b3706752e11f6227fcac844",
+                "reference": "4f10286a128df6b60b3706752e11f6227fcac844",
                 "shasum": ""
             },
             "require": {
@@ -2611,7 +2283,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2638,7 +2310,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:38:11+00:00"
+            "time": "2018-05-16T14:42:13+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -2850,12 +2522,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "4a8bf11547e139e77b651365113fc12850c43d9a"
+                "reference": "1fc2d96ee97d5052f44662563587a0213895343d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/4a8bf11547e139e77b651365113fc12850c43d9a",
-                "reference": "4a8bf11547e139e77b651365113fc12850c43d9a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/1fc2d96ee97d5052f44662563587a0213895343d",
+                "reference": "1fc2d96ee97d5052f44662563587a0213895343d",
                 "shasum": ""
             },
             "require": {
@@ -2892,7 +2564,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:41+00:00"
+            "time": "2018-05-26T14:16:30+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -2945,7 +2617,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "better-serializer/better-serializer": 20,
         "phpbench/phpbench": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -12,21 +12,23 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/better-serializer/better-serializer.git",
-                "reference": "cb2b50db6df65e66c844ae585c249f744770503e"
+                "reference": "7c4c74057b86365a502bed8bc558d94e12ab8730"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/cb2b50db6df65e66c844ae585c249f744770503e",
-                "reference": "cb2b50db6df65e66c844ae585c249f744770503e",
+                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/7c4c74057b86365a502bed8bc558d94e12ab8730",
+                "reference": "7c4c74057b86365a502bed8bc558d94e12ab8730",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "^1.3",
+                "doctrine/cache": "^v1.7",
                 "doctrine/instantiator": "^1.0",
                 "league/flysystem": "^1.0",
                 "marc-mabe/php-enum": "^2.3",
                 "php": "^7.1",
                 "phpdocumentor/reflection-docblock": "^3.0",
+                "pimple/pimple": "^3.0",
                 "roave/security-advisories": "dev-master"
             },
             "require-dev": {
@@ -38,7 +40,6 @@
                 "phpro/grumphp": "^v0.12",
                 "phpstan/phpstan": "^0.7",
                 "phpunit/phpunit": "^6.0",
-                "pimple/pimple": "^3.0",
                 "satooshi/php-coveralls": "~1.0",
                 "sebastian/phpcpd": "^3.0",
                 "sensiolabs/security-checker": "^4.0",
@@ -62,7 +63,7 @@
                 }
             ],
             "description": "General de/serializer for vatious serialization formats.",
-            "time": "2017-09-05 21:49:40"
+            "time": "2017-09-08 19:46:16"
         },
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "290877dd39af63389425c290cc6af3c6",
+    "content-hash": "d8f247210577c16221cabebc4a63f6d0",
     "packages": [
         {
             "name": "beberlei/assert",
-            "version": "v2.7.6",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beberlei/assert.git",
-                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+                "reference": "fd8dc8f6de4645ccf4d1a0b38a6b8fdaf2e8b337"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beberlei/assert/zipball/8726e183ebbb0169cb6cb4832e22ebd355524563",
-                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/fd8dc8f6de4645ccf4d1a0b38a6b8fdaf2e8b337",
+                "reference": "fd8dc8f6de4645ccf4d1a0b38a6b8fdaf2e8b337",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.1.1",
-                "phpunit/phpunit": "^4|^5"
+                "phpunit/phpunit": "^4.8.35|^5.7"
             },
             "type": "library",
             "autoload": {
@@ -59,7 +59,7 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2017-05-04T02:00:24+00:00"
+            "time": "2017-11-30T13:25:15+00:00"
         },
         {
             "name": "better-serializer/better-serializer",
@@ -67,26 +67,27 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/better-serializer/better-serializer.git",
-                "reference": "86ead98d510e7b4e05f9320cb8c8e4913bf944e4"
+                "reference": "8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/86ead98d510e7b4e05f9320cb8c8e4913bf944e4",
-                "reference": "86ead98d510e7b4e05f9320cb8c8e4913bf944e4",
+                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740",
+                "reference": "8e6f1ae4ae67bb6d992b7f1f91ced2e9a32e0740",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "^1.3",
                 "doctrine/cache": "^v1.7",
                 "doctrine/instantiator": "^1.0",
+                "infection/infection": "^0.7",
                 "league/flysystem": "^1.0",
                 "marc-mabe/php-enum": "^2.3",
                 "php": "^7.1",
                 "phpdocumentor/reflection-docblock": "^3.0",
-                "pimple/pimple": "^3.0",
-                "roave/security-advisories": "dev-master"
+                "pimple/pimple": "^3.0"
             },
             "require-dev": {
+                "doctrine/collections": "^1.5",
                 "friendsofphp/php-cs-fixer": "^2.5",
                 "jakub-onderka/php-parallel-lint": "^0.9.2",
                 "jms/serializer": "^1.8",
@@ -118,7 +119,63 @@
                 }
             ],
             "description": "General de/serializer for vatious serialization formats.",
-            "time": "2017-09-17 15:23:05"
+            "time": "2018-01-03T20:12:15+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "134242fce6195119baf9ae553984e96ff888c2c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/134242fce6195119baf9ae553984e96ff888c2c5",
+                "reference": "134242fce6195119baf9ae553984e96ff888c2c5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-12-17T13:07:26+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -157,12 +214,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "2497b1f9db56278d3ad2248f9e4bdbbbaa271c3e"
+                "reference": "fe71864318b4912198a317783392c639221ec2fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/2497b1f9db56278d3ad2248f9e4bdbbbaa271c3e",
-                "reference": "2497b1f9db56278d3ad2248f9e4bdbbbaa271c3e",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/fe71864318b4912198a317783392c639221ec2fd",
+                "reference": "fe71864318b4912198a317783392c639221ec2fd",
                 "shasum": ""
             },
             "require": {
@@ -171,12 +228,12 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -217,7 +274,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-07-22 11:08:38"
+            "time": "2017-12-24T17:33:14+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -225,12 +282,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "beb0fa35b61e9073f8612d9ffd34920bdaec406a"
+                "reference": "e3fcea0d1af20ec7e236e37efaca378071adbae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/beb0fa35b61e9073f8612d9ffd34920bdaec406a",
-                "reference": "beb0fa35b61e9073f8612d9ffd34920bdaec406a",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/e3fcea0d1af20ec7e236e37efaca378071adbae0",
+                "reference": "e3fcea0d1af20ec7e236e37efaca378071adbae0",
                 "shasum": ""
             },
             "require": {
@@ -293,7 +350,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2017-08-25 06:51:37"
+            "time": "2017-12-18T07:23:23+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -301,23 +358,21 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "8520afa0d55f9b3aba1070a9bf65d4b0d9fb7727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8520afa0d55f9b3aba1070a9bf65d4b0d9fb7727",
+                "reference": "8520afa0d55f9b3aba1070a9bf65d4b0d9fb7727",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpunit/phpunit": "^6.2.3"
             },
             "type": "library",
             "extra": {
@@ -347,7 +402,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22 11:58:36"
+            "time": "2017-12-22T05:44:00+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -401,7 +456,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2017-07-24 09:37:08"
+            "time": "2017-07-24T09:37:08+00:00"
         },
         {
             "name": "egeloen/serializer",
@@ -476,7 +531,67 @@
             "keywords": [
                 "serializer"
             ],
-            "time": "2017-02-27 21:35:23"
+            "time": "2017-02-27T21:35:23+00:00"
+        },
+        {
+            "name": "infection/infection",
+            "version": "0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/infection.git",
+                "reference": "6c237470a268196f82df70179d1a57d0e6cdfa57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/infection/zipball/6c237470a268196f82df70179d1a57d0e6cdfa57",
+                "reference": "6c237470a268196f82df70179d1a57d0e6cdfa57",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^3.0",
+                "padraic/phar-updater": "^1.0.4",
+                "php": "^7.0",
+                "pimple/pimple": "^3.0",
+                "sebastian/diff": "^1.4|^2.0",
+                "symfony/console": "^3.2 || ^4.0",
+                "symfony/finder": "^3.2 || ^4.0",
+                "symfony/process": "^3.2 || ^4.0",
+                "symfony/yaml": "^3.2 || ^4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.1"
+            },
+            "bin": [
+                "bin/infection"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com",
+                    "homepage": "https://twitter.com/maks_rafalko"
+                }
+            ],
+            "description": "Infection is a Mutation Testing framework for PHP. The mutation adequacy score can be used to measure the effectiveness of a test set in terms of its ability to detect faults.",
+            "keywords": [
+                "coverage",
+                "mutant",
+                "mutation framework",
+                "mutation testing",
+                "testing",
+                "unit testing"
+            ],
+            "time": "2017-12-22T23:03:31+00:00"
         },
         {
             "name": "jms/metadata",
@@ -562,7 +677,7 @@
                 "Apache2"
             ],
             "description": "A library for easily creating recursive-descent parsers.",
-            "time": "2014-07-08 16:40:41"
+            "time": "2014-07-08T16:40:41+00:00"
         },
         {
             "name": "jms/serializer",
@@ -570,12 +685,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "ef6000e98f0d35afff98623cd7b6b731aed20159"
+                "reference": "62c7ff6d61f8692eac8be024c542b3d9d0ab8c8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/ef6000e98f0d35afff98623cd7b6b731aed20159",
-                "reference": "ef6000e98f0d35afff98623cd7b6b731aed20159",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/62c7ff6d61f8692eac8be024c542b3d9d0ab8c8a",
+                "reference": "62c7ff6d61f8692eac8be024c542b3d9d0ab8c8a",
                 "shasum": ""
             },
             "require": {
@@ -598,6 +713,8 @@
                 "jackalope/jackalope-doctrine-dbal": "^1.1.5",
                 "phpunit/phpunit": "^4.8|^5.0",
                 "propel/propel1": "~1.7",
+                "psr/container": "^1.0",
+                "symfony/dependency-injection": "^2.7|^3.3|^4.0",
                 "symfony/expression-language": "^2.6|^3.0",
                 "symfony/filesystem": "^2.1",
                 "symfony/form": "~2.1|^3.0",
@@ -614,7 +731,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.10-dev"
                 }
             },
             "autoload": {
@@ -645,7 +762,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-08-25 09:12:44"
+            "time": "2017-11-30T18:23:40+00:00"
         },
         {
             "name": "league/flysystem",
@@ -653,12 +770,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "3245df3acae2dded99694b499d3bbf937679c8f3"
+                "reference": "c847ed51212861d746a4c3eed7632b07328a926f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3245df3acae2dded99694b499d3bbf937679c8f3",
-                "reference": "3245df3acae2dded99694b499d3bbf937679c8f3",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/c847ed51212861d746a4c3eed7632b07328a926f",
+                "reference": "c847ed51212861d746a4c3eed7632b07328a926f",
                 "shasum": ""
             },
             "require": {
@@ -669,12 +786,13 @@
             },
             "require-dev": {
                 "ext-fileinfo": "*",
-                "mockery/mockery": "~0.9",
-                "phpspec/phpspec": "^2.2",
-                "phpunit/phpunit": "~4.8"
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
                 "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
                 "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
                 "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
@@ -728,7 +846,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-09-04 09:35:39"
+            "time": "2018-01-01T13:00:16+00:00"
         },
         {
             "name": "lstrojny/functional-php",
@@ -927,20 +1045,191 @@
                 "type-hint",
                 "typehint"
             ],
-            "time": "2017-07-02 11:49:04"
+            "time": "2017-07-02T11:49:04+00:00"
         },
         {
-            "name": "paragonie/random_compat",
-            "version": "v2.0.10",
+            "name": "nikic/php-parser",
+            "version": "3.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/579f4ce846734a1cf55d6a531d00ca07a43e3cda",
+                "reference": "579f4ce846734a1cf55d6a531d00ca07a43e3cda",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|~5.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2017-12-26T14:43:21+00:00"
+        },
+        {
+            "name": "padraic/humbug_get_contents",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/humbug/file_get_contents.git",
+                "reference": "6e6c47af83cb98c610f4ba7d06ee809ad59ede1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/humbug/file_get_contents/zipball/6e6c47af83cb98c610f4ba7d06ee809ad59ede1b",
+                "reference": "6e6c47af83cb98c610f4ba7d06ee809ad59ede1b",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "ext-openssl": "*",
+                "php": "^5.3 || ^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.1",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\": "src/"
+                },
+                "files": [
+                    "src/function.php",
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Théo Fidry",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Secure wrapper for accessing HTTPS resources with file_get_contents for PHP 5.3+",
+            "homepage": "https://github.com/padraic/file_get_contents",
+            "keywords": [
+                "download",
+                "file_get_contents",
+                "http",
+                "https",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-07-10T10:32:34+00:00"
+        },
+        {
+            "name": "padraic/phar-updater",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/humbug/phar-updater.git",
+                "reference": "e5a5da3dc3344031271157c7f10b0fa04afffa9b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/humbug/phar-updater/zipball/e5a5da3dc3344031271157c7f10b0fa04afffa9b",
+                "reference": "e5a5da3dc3344031271157c7f10b0fa04afffa9b",
+                "shasum": ""
+            },
+            "require": {
+                "padraic/humbug_get_contents": "^1.0",
+                "php": "^5.6|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.5|^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\SelfUpdate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                }
+            ],
+            "description": "A thing to make PHAR self-updating easy and secure.",
+            "keywords": [
+                "humbug",
+                "phar",
+                "self-update",
+                "update"
+            ],
+            "time": "2017-11-01T16:56:56+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -975,7 +1264,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:27:32+00:00"
+            "time": "2017-09-27T21:40:39+00:00"
         },
         {
             "name": "phpbench/container",
@@ -1069,12 +1358,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "5869bd69f217015a2d62757dcac46c62ef417269"
+                "reference": "ce48bdfc05e766a54bd748515336f2d8a6bdd91d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/5869bd69f217015a2d62757dcac46c62ef417269",
-                "reference": "5869bd69f217015a2d62757dcac46c62ef417269",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/ce48bdfc05e766a54bd748515336f2d8a6bdd91d",
+                "reference": "ce48bdfc05e766a54bd748515336f2d8a6bdd91d",
                 "shasum": ""
             },
             "require": {
@@ -1095,13 +1384,19 @@
                 "symfony/filesystem": "^2.4|^3.0|^4.0",
                 "symfony/finder": "^2.4|^3.0|^4.0",
                 "symfony/options-resolver": "^2.6|^3.0|^4.0",
-                "symfony/process": "^2.1|^3.0|^4.0"
+                "symfony/process": "^2.1|^3.0|^4.0",
+                "webmozart/path-util": "^2.3"
             },
             "require-dev": {
                 "doctrine/dbal": "^2.4",
                 "liip/rmt": "^1.2",
                 "padraic/phar-updater": "^1.0",
+                "phpstan/phpstan": "^0.8.5",
                 "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-curl": "For (web) reports extension",
+                "ext-xdebug": "For XDebug profiling extension."
             },
             "bin": [
                 "bin/phpbench"
@@ -1116,7 +1411,8 @@
                 "psr-4": {
                     "PhpBench\\": "lib/",
                     "PhpBench\\Extensions\\Dbal\\": "extensions/dbal/lib/",
-                    "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/"
+                    "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/",
+                    "PhpBench\\Extensions\\Reports\\": "extensions/reports/lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1130,7 +1426,7 @@
                 }
             ],
             "description": "PHP Benchmarking Framework",
-            "time": "2017-07-27 14:50:30"
+            "time": "2018-01-03T09:11:51+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -1186,12 +1482,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "a046af61c36e9162372f205de091a1cab7340f1c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/a046af61c36e9162372f205de091a1cab7340f1c",
-                "reference": "a046af61c36e9162372f205de091a1cab7340f1c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -1232,25 +1528,25 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-04-30 11:58:12"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.3",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/86e24012a3139b42a7b71155cfaa325389f00f1f",
-                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
@@ -1277,7 +1573,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-29T19:37:41+00:00"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1424,7 +1720,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2017-08-23 11:42:00"
+            "time": "2017-08-23T11:42:00+00:00"
         },
         {
             "name": "psr/cache",
@@ -1470,7 +1766,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-10-13 14:48:10"
+            "time": "2016-10-13T14:48:10+00:00"
         },
         {
             "name": "psr/container",
@@ -1519,7 +1815,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-06-28 15:35:32"
+            "time": "2017-06-28T15:35:32+00:00"
         },
         {
             "name": "psr/log",
@@ -1566,7 +1862,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -1574,12 +1870,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24"
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/753fa598e8f3b9966c886fe13f370baa45ef0e24",
-                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
                 "shasum": ""
             },
             "require": {
@@ -1614,164 +1910,79 @@
                 "psr-16",
                 "simple-cache"
             ],
-            "time": "2017-01-02 13:31:39"
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
-            "name": "roave/security-advisories",
+            "name": "sebastian/diff",
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "f40f874cb7139abb9309fa63a31fd37bb49ddd3e"
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "0fd4d14dd707808a95ca67ada62c15f9a9186b15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f40f874cb7139abb9309fa63a31fd37bb49ddd3e",
-                "reference": "f40f874cb7139abb9309fa63a31fd37bb49ddd3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/0fd4d14dd707808a95ca67ada62c15f9a9186b15",
+                "reference": "0fd4d14dd707808a95ca67ada62c15f9a9186b15",
                 "shasum": ""
             },
-            "conflict": {
-                "adodb/adodb-php": "<5.20.6",
-                "amphp/artax": ">=2,<2.0.6|<1.0.6",
-                "aws/aws-sdk-php": ">=3,<3.2.1",
-                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-                "cakephp/cakephp": ">=3,<3.0.15|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=1.3,<1.3.18|>=2.7,<2.7.6|>=3.1,<3.1.4",
-                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-                "cartalyst/sentry": "<2.1",
-                "codeigniter/framework": "<=3.0.6",
-                "composer/composer": "<=1.0.0-alpha11",
-                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/core": ">=2,<3.5.28",
-                "contao/core-bundle": ">=4,<4.4.1",
-                "doctrine/annotations": ">=1,<1.2.7",
-                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
-                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
-                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
-                "doctrine/doctrine-bundle": "<1.5.2",
-                "doctrine/doctrine-module": "<=0.7.1",
-                "doctrine/mongodb-odm": ">=1,<1.0.2",
-                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
-                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
-                "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=8,<8.3.7",
-                "drupal/drupal": ">=8,<8.3.7",
-                "firebase/php-jwt": "<2",
-                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
-                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
-                "gregwar/rst": "<1.0.3",
-                "guzzlehttp/guzzle": ">=6,<6.2.1|>=4.0.0-rc2,<4.2.4|>=5,<5.3.1",
-                "illuminate/auth": ">=4,<4.0.99|>=4.1,<4.1.26",
-                "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
-                "joomla/session": "<1.3.1",
-                "laravel/framework": ">=4,<4.0.99|>=4.1,<4.1.29",
-                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
-                "magento/magento1ce": ">=1.5.0.1,<1.9.3.2",
-                "magento/magento1ee": ">=1.9,<1.14.3.2",
-                "magento/magento2ce": ">=2,<2.2",
-                "monolog/monolog": ">=1.8,<1.12",
-                "namshi/jose": "<2.2",
-                "onelogin/php-saml": "<2.10.4",
-                "oro/crm": ">=1.7,<1.7.4",
-                "oro/platform": ">=1.7,<1.7.4",
-                "phpmailer/phpmailer": ">=5,<5.2.24",
-                "pusher/pusher-php-server": "<2.2.1",
-                "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
-                "shopware/shopware": "<4.4|>=5,<5.2.16",
-                "silverstripe/cms": ">=3.1,<3.1.11|>=3,<=3.0.11",
-                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": ">=3,<3.3",
-                "silverstripe/userforms": "<3",
-                "simplesamlphp/saml2": "<1.8.1|>=1.9,<1.9.1|>=1.10,<1.10.3|>=2,<2.3.3",
-                "simplesamlphp/simplesamlphp": "<1.14.15",
-                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
-                "socalnick/scn-social-auth": "<1.15.2",
-                "squizlabs/php_codesniffer": ">=1,<2.8.1",
-                "swiftmailer/swiftmailer": ">=4,<5.4.5",
-                "symfony/dependency-injection": ">=2,<2.0.17",
-                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.7",
-                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
-                "symfony/http-foundation": ">=2,<2.3.27|>=2.4,<2.5.11|>=2.6,<2.6.6",
-                "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
-                "symfony/routing": ">=2,<2.0.19",
-                "symfony/security": ">=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.3,<2.3.37|>=2.4,<2.6.13|>=2.7,<2.7.9|>=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9",
-                "symfony/security-core": ">=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.8,<2.8.6|>=3,<3.0.6|>=2.4,<2.6.13|>=2.7,<2.7.9",
-                "symfony/security-http": ">=2.4,<2.7.13|>=2.3,<2.3.41|>=2.8,<2.8.6|>=3,<3.0.6",
-                "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.13|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.8,<2.8.6|>=3,<3.0.6",
-                "symfony/translation": ">=2,<2.0.17",
-                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
-                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
-                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
-                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
-                "twig/twig": "<1.20",
-                "typo3/cms": ">=6.2,<6.2.30|>=8,<8.6.1|>=7,<7.6.16",
-                "typo3/flow": ">=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5|>=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1",
-                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
-                "willdurand/js-translation-bundle": "<2.1.1",
-                "yiisoft/yii": ">=1.1.14,<1.1.15",
-                "yiisoft/yii2": "<2.0.5",
-                "yiisoft/yii2-bootstrap": "<2.0.4",
-                "yiisoft/yii2-dev": "<2.0.4",
-                "yiisoft/yii2-gii": "<2.0.4",
-                "yiisoft/yii2-jui": "<2.0.4",
-                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
-                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
-                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
-                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
-                "zendframework/zend-diactoros": ">=1,<1.0.4",
-                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-http": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.3,<2.3.8|>=2.4,<2.4.1",
-                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
-                "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
-                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
-                "zendframework/zend-validator": ">=2.3,<2.3.6",
-                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-                "zendframework/zendframework": ">=2,<2.4.11|>=2.5,<2.5.1",
-                "zendframework/zendframework1": "<1.12.20",
-                "zendframework/zendopenid": ">=2,<2.0.2",
-                "zendframework/zendxml": ">=1,<1.0.1",
-                "zf-commons/zfc-user": "<1.2.2",
-                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
-                "zfr/zfr-oauth2-server-module": "<0.1.2"
+            "require": {
+                "php": "^7.0"
             },
-            "type": "metapackage",
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "role": "maintainer"
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2017-08-17T12:55:16+00:00"
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-12-14T13:13:00+00:00"
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77"
+                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
-                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9b355654ea99460397b89c132b5c1087b6bf4473",
+                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "bin": [
                 "bin/jsonlint"
@@ -1800,7 +2011,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2017-06-18T15:11:04+00:00"
+            "time": "2018-01-03T12:13:57+00:00"
         },
         {
             "name": "symfony/cache",
@@ -1808,12 +2019,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "d9744533b28c519d46c8ff81dab186aeece1ddda"
+                "reference": "5725378078bc4e1fe3c3414e9cc0e63d7de47fff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/d9744533b28c519d46c8ff81dab186aeece1ddda",
-                "reference": "d9744533b28c519d46c8ff81dab186aeece1ddda",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/5725378078bc4e1fe3c3414e9cc0e63d7de47fff",
+                "reference": "5725378078bc4e1fe3c3414e9cc0e63d7de47fff",
                 "shasum": ""
             },
             "require": {
@@ -1870,7 +2081,7 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2017-09-05 18:44:31"
+            "time": "2018-01-03T17:14:19+00:00"
         },
         {
             "name": "symfony/console",
@@ -1878,12 +2089,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "78d1370ad8d26a3f1bc117a2ac3af419aaf5c37e"
+                "reference": "8394c8ef121949e8f858f13bc1e34f05169e4e7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/78d1370ad8d26a3f1bc117a2ac3af419aaf5c37e",
-                "reference": "78d1370ad8d26a3f1bc117a2ac3af419aaf5c37e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8394c8ef121949e8f858f13bc1e34f05169e4e7d",
+                "reference": "8394c8ef121949e8f858f13bc1e34f05169e4e7d",
                 "shasum": ""
             },
             "require": {
@@ -1892,13 +2103,13 @@
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3",
+                "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.3|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
                 "symfony/lock": "~3.4|~4.0",
                 "symfony/process": "~3.3|~4.0"
@@ -1939,7 +2150,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-03 15:31:40"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1947,12 +2158,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "96bc445c20a66daacb138e5f4c53bf29a4b64c9c"
+                "reference": "d6bc1c9e625a76fbe07087c6004455d58ad3a900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/96bc445c20a66daacb138e5f4c53bf29a4b64c9c",
-                "reference": "96bc445c20a66daacb138e5f4c53bf29a4b64c9c",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/d6bc1c9e625a76fbe07087c6004455d58ad3a900",
+                "reference": "d6bc1c9e625a76fbe07087c6004455d58ad3a900",
                 "shasum": ""
             },
             "require": {
@@ -1968,7 +2179,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1995,7 +2206,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-03 14:49:52"
+            "time": "2018-01-03T17:15:33+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2003,12 +2214,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "df8e441d071093d215272c459581b06e17e1783e"
+                "reference": "94281d227ea7a154eb23c618d06c9c2ee76c1e59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/df8e441d071093d215272c459581b06e17e1783e",
-                "reference": "df8e441d071093d215272c459581b06e17e1783e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/94281d227ea7a154eb23c618d06c9c2ee76c1e59",
+                "reference": "94281d227ea7a154eb23c618d06c9c2ee76c1e59",
                 "shasum": ""
             },
             "require": {
@@ -2017,7 +2228,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2044,7 +2255,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-02 05:32:45"
+            "time": "2018-01-03T07:38:11+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2052,12 +2263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "d04fb01c1aa6e3f2f62e5505b62ede74f7cd4d1a"
+                "reference": "db4ab92faa7b893bd96e6a2e29251ff8bd2a904d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/d04fb01c1aa6e3f2f62e5505b62ede74f7cd4d1a",
-                "reference": "d04fb01c1aa6e3f2f62e5505b62ede74f7cd4d1a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/db4ab92faa7b893bd96e6a2e29251ff8bd2a904d",
+                "reference": "db4ab92faa7b893bd96e6a2e29251ff8bd2a904d",
                 "shasum": ""
             },
             "require": {
@@ -2066,7 +2277,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2093,7 +2304,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01 22:17:54"
+            "time": "2018-01-03T07:38:11+00:00"
         },
         {
             "name": "symfony/inflector",
@@ -2101,12 +2312,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/inflector.git",
-                "reference": "8740990f67ec9f89bfa116d11bad2990dd510ece"
+                "reference": "242a9dd0c961e787bc40a02309315167b5f479bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/inflector/zipball/8740990f67ec9f89bfa116d11bad2990dd510ece",
-                "reference": "8740990f67ec9f89bfa116d11bad2990dd510ece",
+                "url": "https://api.github.com/repos/symfony/inflector/zipball/242a9dd0c961e787bc40a02309315167b5f479bc",
+                "reference": "242a9dd0c961e787bc40a02309315167b5f479bc",
                 "shasum": ""
             },
             "require": {
@@ -2115,7 +2326,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2150,7 +2361,7 @@
                 "symfony",
                 "words"
             ],
-            "time": "2017-08-31 20:46:21"
+            "time": "2018-01-03T17:15:33+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2158,12 +2369,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "9e2ed813a4683bfa310a45d416b922fd7ede638c"
+                "reference": "f31f4d3ce4eaf7597abc41bd5ba53d634c2fdb0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/9e2ed813a4683bfa310a45d416b922fd7ede638c",
-                "reference": "9e2ed813a4683bfa310a45d416b922fd7ede638c",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/f31f4d3ce4eaf7597abc41bd5ba53d634c2fdb0e",
+                "reference": "f31f4d3ce4eaf7597abc41bd5ba53d634c2fdb0e",
                 "shasum": ""
             },
             "require": {
@@ -2204,7 +2415,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2017-08-03 09:34:20"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -2212,12 +2423,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "cec32398a973a9bfe9d2f94f4b5d5e186b40b698"
+                "reference": "04f62674339602def515bff4bc6901fc1d4951e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/cec32398a973a9bfe9d2f94f4b5d5e186b40b698",
-                "reference": "cec32398a973a9bfe9d2f94f4b5d5e186b40b698",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/04f62674339602def515bff4bc6901fc1d4951e8",
+                "reference": "04f62674339602def515bff4bc6901fc1d4951e8",
                 "shasum": ""
             },
             "require": {
@@ -2226,10 +2437,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Apcu\\": ""
+                },
                 "files": [
                     "bootstrap.php"
                 ]
@@ -2257,7 +2471,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-07-05 15:09:33"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2265,12 +2479,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+                "reference": "750a2b259dd68436e3b918a4241e80b023a80663"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/750a2b259dd68436e3b918a4241e80b023a80663",
+                "reference": "750a2b259dd68436e3b918a4241e80b023a80663",
                 "shasum": ""
             },
             "require": {
@@ -2282,7 +2496,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -2316,7 +2530,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14 15:44:48"
+            "time": "2017-12-17T16:08:10+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -2324,12 +2538,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f"
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/b6482e68974486984f59449ecea1fbbb22ff840f",
-                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
                 "shasum": ""
             },
             "require": {
@@ -2339,7 +2553,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -2375,7 +2589,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14 15:44:48"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/process",
@@ -2383,12 +2597,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2750e6512a31bea2bcbd088a7e231cb4192e99da"
+                "reference": "437ffa07721b8441c9acfa3c749485dffbaae09e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2750e6512a31bea2bcbd088a7e231cb4192e99da",
-                "reference": "2750e6512a31bea2bcbd088a7e231cb4192e99da",
+                "url": "https://api.github.com/repos/symfony/process/zipball/437ffa07721b8441c9acfa3c749485dffbaae09e",
+                "reference": "437ffa07721b8441c9acfa3c749485dffbaae09e",
                 "shasum": ""
             },
             "require": {
@@ -2397,7 +2611,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2424,7 +2638,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-12 14:12:10"
+            "time": "2018-01-03T07:38:11+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -2432,12 +2646,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "2740d63e7b3682832a7404bc23b44f651f953f35"
+                "reference": "a6e8c778b220dfd5cd5f5dcb09f87ee232dd608a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/2740d63e7b3682832a7404bc23b44f651f953f35",
-                "reference": "2740d63e7b3682832a7404bc23b44f651f953f35",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/a6e8c778b220dfd5cd5f5dcb09f87ee232dd608a",
+                "reference": "a6e8c778b220dfd5cd5f5dcb09f87ee232dd608a",
                 "shasum": ""
             },
             "require": {
@@ -2492,7 +2706,7 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2017-09-03 08:01:11"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -2500,18 +2714,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "ca9a7c8b8170246b8414bec95fa60d41b372afd9"
+                "reference": "7a392ecf139e786a13cb894a5c6338aedada771f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/ca9a7c8b8170246b8414bec95fa60d41b372afd9",
-                "reference": "ca9a7c8b8170246b8414bec95fa60d41b372afd9",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/7a392ecf139e786a13cb894a5c6338aedada771f",
+                "reference": "7a392ecf139e786a13cb894a5c6338aedada771f",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
+                "phpdocumentor/type-resolver": "<0.2.1",
                 "symfony/dependency-injection": "<3.2",
                 "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
                 "symfony/property-info": "<3.1",
@@ -2569,7 +2784,7 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-17 13:38:59"
+            "time": "2018-01-02T15:47:46+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2577,12 +2792,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "bd9dcffc3eb2984afd4c534864f2802eccd3435a"
+                "reference": "25c192f25721a74084272671f658797d9e0e0146"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/bd9dcffc3eb2984afd4c534864f2802eccd3435a",
-                "reference": "bd9dcffc3eb2984afd4c534864f2802eccd3435a",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/25c192f25721a74084272671f658797d9e0e0146",
+                "reference": "25c192f25721a74084272671f658797d9e0e0146",
                 "shasum": ""
             },
             "require": {
@@ -2627,7 +2842,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-08-30 06:19:03"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2677,7 +2892,53 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:41"
+            "time": "2016-11-23T20:04:41+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "95a8f7ad150c2a3773ff3c3d04f557a24c99cfd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/95a8f7ad150c2a3773ff3c3d04f557a24c99cfd2",
+                "reference": "95a8f7ad150c2a3773ff3c3d04f557a24c99cfd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2016-08-15T15:31:42+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -67,12 +67,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/better-serializer/better-serializer.git",
-                "reference": "7c4c74057b86365a502bed8bc558d94e12ab8730"
+                "reference": "86ead98d510e7b4e05f9320cb8c8e4913bf944e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/7c4c74057b86365a502bed8bc558d94e12ab8730",
-                "reference": "7c4c74057b86365a502bed8bc558d94e12ab8730",
+                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/86ead98d510e7b4e05f9320cb8c8e4913bf944e4",
+                "reference": "86ead98d510e7b4e05f9320cb8c8e4913bf944e4",
                 "shasum": ""
             },
             "require": {
@@ -118,7 +118,7 @@
                 }
             ],
             "description": "General de/serializer for vatious serialization formats.",
-            "time": "2017-09-08 19:46:16"
+            "time": "2017-09-17 15:23:05"
         },
         {
             "name": "container-interop/container-interop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,83 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e84f44c531a2d8ad6f2cf05408f6774a",
-    "content-hash": "467f659322c65a701bc504198893d6d6",
+    "content-hash": "82b2dc7983c97ee3cfee6413ce6446d0",
     "packages": [
+        {
+            "name": "better-serializer/better-serializer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/better-serializer/better-serializer.git",
+                "reference": "cb2b50db6df65e66c844ae585c249f744770503e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/better-serializer/better-serializer/zipball/cb2b50db6df65e66c844ae585c249f744770503e",
+                "reference": "cb2b50db6df65e66c844ae585c249f744770503e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.3",
+                "doctrine/instantiator": "^1.0",
+                "league/flysystem": "^1.0",
+                "marc-mabe/php-enum": "^2.3",
+                "php": "^7.1",
+                "phpdocumentor/reflection-docblock": "^3.0",
+                "roave/security-advisories": "dev-master"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.5",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "jms/serializer": "^1.8",
+                "nikic/php-parser": "^3.0",
+                "phpmd/phpmd": "^2.6",
+                "phpro/grumphp": "^v0.12",
+                "phpstan/phpstan": "^0.7",
+                "phpunit/phpunit": "^6.0",
+                "pimple/pimple": "^3.0",
+                "satooshi/php-coveralls": "~1.0",
+                "sebastian/phpcpd": "^3.0",
+                "sensiolabs/security-checker": "^4.0",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/var-dumper": "^v3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BetterSerializer\\": "src/BetterSerializer/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Fris / Rastusik",
+                    "email": "rasta@lj.sk"
+                }
+            ],
+            "description": "General de/serializer for vatious serialization formats.",
+            "time": "2017-09-05 21:49:40"
+        },
         {
             "name": "doctrine/annotations",
             "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "1fcf863da06d8f305fc031ee87360f087d854c8d"
+                "reference": "2497b1f9db56278d3ad2248f9e4bdbbbaa271c3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/1fcf863da06d8f305fc031ee87360f087d854c8d",
-                "reference": "1fcf863da06d8f305fc031ee87360f087d854c8d",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/2497b1f9db56278d3ad2248f9e4bdbbbaa271c3e",
+                "reference": "2497b1f9db56278d3ad2248f9e4bdbbbaa271c3e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
@@ -32,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -73,7 +130,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-01-09 00:44:36"
+            "time": "2017-07-22 11:08:38"
         },
         {
             "name": "doctrine/cache",
@@ -81,28 +138,35 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "e64d917c29fd8bb4ac13e122ec6de9721c4cf0e7"
+                "reference": "beb0fa35b61e9073f8612d9ffd34920bdaec406a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/e64d917c29fd8bb4ac13e122ec6de9721c4cf0e7",
-                "reference": "e64d917c29fd8bb4ac13e122ec6de9721c4cf0e7",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/beb0fa35b61e9073f8612d9ffd34920bdaec406a",
+                "reference": "beb0fa35b61e9073f8612d9ffd34920bdaec406a",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.6|~7.0"
+                "php": "~7.1"
             },
             "conflict": {
                 "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7",
-                "predis/predis": "~1.0"
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^1.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^6.3",
+                "predis/predis": "~1.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -142,7 +206,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2017-01-20 09:27:09"
+            "time": "2017-08-25 06:51:37"
         },
         {
             "name": "doctrine/instantiator",
@@ -150,28 +214,28 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "68099b02b60bbf3b088ff5cb67bf506770ef9cac"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/68099b02b60bbf3b088ff5cb67bf506770ef9cac",
-                "reference": "68099b02b60bbf3b088ff5cb67bf506770ef9cac",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -196,7 +260,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-01-23 09:23:06"
+            "time": "2017-07-22 11:58:36"
         },
         {
             "name": "doctrine/lexer",
@@ -204,12 +268,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+                "reference": "cc709ba91eee09540091ad5a5f2616727662e41b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/cc709ba91eee09540091ad5a5f2616727662e41b",
+                "reference": "cc709ba91eee09540091ad5a5f2616727662e41b",
                 "shasum": ""
             },
             "require": {
@@ -222,8 +286,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Lexer\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -250,7 +314,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2017-07-24 09:37:08"
         },
         {
             "name": "egeloen/serializer",
@@ -258,34 +322,36 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/egeloen/ivory-serializer.git",
-                "reference": "7bb7230279fd36250702b4acfd39a046b3b7b789"
+                "reference": "e1b21223bb014f8ca62b30d10b33a986f2a2c334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egeloen/ivory-serializer/zipball/7bb7230279fd36250702b4acfd39a046b3b7b789",
-                "reference": "7bb7230279fd36250702b4acfd39a046b3b7b789",
+                "url": "https://api.github.com/repos/egeloen/ivory-serializer/zipball/e1b21223bb014f8ca62b30d10b33a986f2a2c334",
+                "reference": "e1b21223bb014f8ca62b30d10b33a986f2a2c334",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0",
                 "doctrine/lexer": "^1.0",
                 "php": "^5.6|^7.0",
-                "symfony/options-resolver": "^2.8|^3.0"
+                "symfony/options-resolver": "^2.7|^3.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.0",
+                "doctrine/annotations": "^1.2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-simplexml": "*",
-                "friendsofphp/php-cs-fixer": "^1.11",
+                "friendsofphp/php-cs-fixer": "^2.0",
                 "nikic/php-parser": "^1.4",
                 "phpdocumentor/reflection": "^3.0",
                 "phpunit/phpunit": "^5.4",
+                "phpunit/phpunit-mock-objects": "^3.2.3",
                 "psr/cache": "^1.0",
-                "symfony/event-dispatcher": "^2.8|^3.0",
-                "symfony/property-access": "^2.8|^3.0",
-                "symfony/property-info": "^2.8|^3.0",
-                "symfony/yaml": "^2.6|^3.0"
+                "symfony/event-dispatcher": "^2.7|^3.0",
+                "symfony/phpunit-bridge": "^2.7|^3.0",
+                "symfony/property-access": "^2.7|^3.0",
+                "symfony/property-info": "^2.7|^3.0",
+                "symfony/yaml": "^2.7|^3.0"
             },
             "suggest": {
                 "doctrine/annotations": "Allow you to use the mapping annotations.",
@@ -323,7 +389,7 @@
             "keywords": [
                 "serializer"
             ],
-            "time": "2017-01-25 22:39:44"
+            "time": "2017-02-27 21:35:23"
         },
         {
             "name": "jms/metadata",
@@ -374,7 +440,7 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2016-12-05 10:18:33"
+            "time": "2016-12-05T10:18:33+00:00"
         },
         {
             "name": "jms/parser-lib",
@@ -413,16 +479,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "1.5.0-RC1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "30d0b79fa6c6839eb8ab73b1b7a7a7bcea35b34a"
+                "reference": "ef6000e98f0d35afff98623cd7b6b731aed20159"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/30d0b79fa6c6839eb8ab73b1b7a7a7bcea35b34a",
-                "reference": "30d0b79fa6c6839eb8ab73b1b7a7a7bcea35b34a",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/ef6000e98f0d35afff98623cd7b6b731aed20159",
+                "reference": "ef6000e98f0d35afff98623cd7b6b731aed20159",
                 "shasum": ""
             },
             "require": {
@@ -435,6 +501,7 @@
                 "phpoption/phpoption": "^1.1"
             },
             "conflict": {
+                "jms/serializer-bundle": "<1.2.1",
                 "twig/twig": "<1.12"
             },
             "require-dev": {
@@ -453,12 +520,14 @@
                 "twig/twig": "~1.12|~2.0"
             },
             "suggest": {
+                "doctrine/cache": "Required if you like to use cache functionality.",
+                "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",
                 "symfony/yaml": "Required if you'd like to serialize data to YAML format."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -468,9 +537,13 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache2"
+                "Apache-2.0"
             ],
             "authors": [
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                },
                 {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
@@ -485,20 +558,166 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-01-19 14:33:19"
+            "time": "2017-08-25 09:12:44"
         },
         {
-            "name": "paragonie/random_compat",
-            "version": "v2.0.4",
+            "name": "league/flysystem",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "3245df3acae2dded99694b499d3bbf937679c8f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
-                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3245df3acae2dded99694b499d3bbf937679c8f3",
+                "reference": "3245df3acae2dded99694b499d3bbf937679c8f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "mockery/mockery": "~0.9",
+                "phpspec/phpspec": "^2.2",
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2017-09-04 09:35:39"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "9803f7ffa5ad8e275c083b0accce5b7de3f90f98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/9803f7ffa5ad8e275c083b0accce5b7de3f90f98",
+                "reference": "9803f7ffa5ad8e275c083b0accce5b7de3f90f98",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "php": "PHP>=5.4 will be required for using trait EnumSerializableTrait"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-2.x": "2.3-dev",
+                    "dev-1.x": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "http://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP 5.3 and upper",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enummap",
+                "enumset",
+                "type-hint",
+                "typehint"
+            ],
+            "time": "2017-07-02 11:49:04"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
                 "shasum": ""
             },
             "require": {
@@ -533,7 +752,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-11-07 23:38:38"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -581,7 +800,153 @@
                 "sequence",
                 "set"
             ],
-            "time": "2015-05-17 12:39:23"
+            "time": "2015-05-17T12:39:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "a046af61c36e9162372f205de091a1cab7340f1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/a046af61c36e9162372f205de091a1cab7340f1c",
+                "reference": "a046af61c36e9162372f205de091a1cab7340f1c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-04-30 11:58:12"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/86e24012a3139b42a7b71155cfaa325389f00f1f",
+                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-08-29T19:37:41+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -631,7 +996,57 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25 16:39:46"
+            "time": "2015-07-25T16:39:46+00:00"
+        },
+        {
+            "name": "pimple/pimple",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Pimple.git",
+                "reference": "b5e5c1809fc323428715aa6a66ddca180e0adc0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/b5e5c1809fc323428715aa6a66ddca180e0adc0f",
+                "reference": "b5e5c1809fc323428715aa6a66ddca180e0adc0f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pimple": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Pimple, a simple Dependency Injection Container",
+            "homepage": "http://pimple.sensiolabs.org",
+            "keywords": [
+                "container",
+                "dependency injection"
+            ],
+            "time": "2017-08-23 11:42:00"
         },
         {
             "name": "psr/cache",
@@ -678,6 +1093,55 @@
                 "psr-6"
             ],
             "time": "2016-10-13 14:48:10"
+        },
+        {
+            "name": "psr/container",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "2cc4a01788191489dc7459446ba832fa79a216a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/2cc4a01788191489dc7459446ba832fa79a216a7",
+                "reference": "2cc4a01788191489dc7459446ba832fa79a216a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-06-28 15:35:32"
         },
         {
             "name": "psr/log",
@@ -775,42 +1239,180 @@
             "time": "2017-01-02 13:31:39"
         },
         {
-            "name": "symfony/cache",
+            "name": "roave/security-advisories",
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "4e0ef50c1925edff3ab2d0925656fdfeb1930390"
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "f40f874cb7139abb9309fa63a31fd37bb49ddd3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/4e0ef50c1925edff3ab2d0925656fdfeb1930390",
-                "reference": "4e0ef50c1925edff3ab2d0925656fdfeb1930390",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f40f874cb7139abb9309fa63a31fd37bb49ddd3e",
+                "reference": "f40f874cb7139abb9309fa63a31fd37bb49ddd3e",
+                "shasum": ""
+            },
+            "conflict": {
+                "adodb/adodb-php": "<5.20.6",
+                "amphp/artax": ">=2,<2.0.6|<1.0.6",
+                "aws/aws-sdk-php": ">=3,<3.2.1",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "cakephp/cakephp": ">=3,<3.0.15|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=1.3,<1.3.18|>=2.7,<2.7.6|>=3.1,<3.1.4",
+                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<2.1",
+                "codeigniter/framework": "<=3.0.6",
+                "composer/composer": "<=1.0.0-alpha11",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/core": ">=2,<3.5.28",
+                "contao/core-bundle": ">=4,<4.4.1",
+                "doctrine/annotations": ">=1,<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<=0.7.1",
+                "doctrine/mongodb-odm": ">=1,<1.0.2",
+                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
+                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
+                "dompdf/dompdf": ">=0.6,<0.6.2",
+                "drupal/core": ">=8,<8.3.7",
+                "drupal/drupal": ">=8,<8.3.7",
+                "firebase/php-jwt": "<2",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "gregwar/rst": "<1.0.3",
+                "guzzlehttp/guzzle": ">=6,<6.2.1|>=4.0.0-rc2,<4.2.4|>=5,<5.3.1",
+                "illuminate/auth": ">=4,<4.0.99|>=4.1,<4.1.26",
+                "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
+                "joomla/session": "<1.3.1",
+                "laravel/framework": ">=4,<4.0.99|>=4.1,<4.1.29",
+                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
+                "magento/magento1ce": ">=1.5.0.1,<1.9.3.2",
+                "magento/magento1ee": ">=1.9,<1.14.3.2",
+                "magento/magento2ce": ">=2,<2.2",
+                "monolog/monolog": ">=1.8,<1.12",
+                "namshi/jose": "<2.2",
+                "onelogin/php-saml": "<2.10.4",
+                "oro/crm": ">=1.7,<1.7.4",
+                "oro/platform": ">=1.7,<1.7.4",
+                "phpmailer/phpmailer": ">=5,<5.2.24",
+                "pusher/pusher-php-server": "<2.2.1",
+                "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
+                "shopware/shopware": "<4.4|>=5,<5.2.16",
+                "silverstripe/cms": ">=3.1,<3.1.11|>=3,<=3.0.11",
+                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/framework": ">=3,<3.3",
+                "silverstripe/userforms": "<3",
+                "simplesamlphp/saml2": "<1.8.1|>=1.9,<1.9.1|>=1.10,<1.10.3|>=2,<2.3.3",
+                "simplesamlphp/simplesamlphp": "<1.14.15",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1",
+                "swiftmailer/swiftmailer": ">=4,<5.4.5",
+                "symfony/dependency-injection": ">=2,<2.0.17",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.7",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
+                "symfony/http-foundation": ">=2,<2.3.27|>=2.4,<2.5.11|>=2.6,<2.6.6",
+                "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
+                "symfony/routing": ">=2,<2.0.19",
+                "symfony/security": ">=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.3,<2.3.37|>=2.4,<2.6.13|>=2.7,<2.7.9|>=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9",
+                "symfony/security-core": ">=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.8,<2.8.6|>=3,<3.0.6|>=2.4,<2.6.13|>=2.7,<2.7.9",
+                "symfony/security-http": ">=2.4,<2.7.13|>=2.3,<2.3.41|>=2.8,<2.8.6|>=3,<3.0.6",
+                "symfony/serializer": ">=2,<2.0.11",
+                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.13|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.8,<2.8.6|>=3,<3.0.6",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
+                "twig/twig": "<1.20",
+                "typo3/cms": ">=6.2,<6.2.30|>=8,<8.6.1|>=7,<7.6.16",
+                "typo3/flow": ">=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5|>=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "yiisoft/yii": ">=1.1.14,<1.1.15",
+                "yiisoft/yii2": "<2.0.5",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.4",
+                "yiisoft/yii2-gii": "<2.0.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-diactoros": ">=1,<1.0.4",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.3,<2.3.8|>=2.4,<2.4.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": ">=2,<2.4.11|>=2.5,<2.5.1",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": ">=2,<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2"
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "time": "2017-08-17T12:55:16+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "3.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "d9744533b28c519d46c8ff81dab186aeece1ddda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/d9744533b28c519d46c8ff81dab186aeece1ddda",
+                "reference": "d9744533b28c519d46c8ff81dab186aeece1ddda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^5.5.9|>=7.0.8",
                 "psr/cache": "~1.0",
                 "psr/log": "~1.0",
-                "psr/simple-cache": "^1.0"
+                "psr/simple-cache": "^1.0",
+                "symfony/polyfill-apcu": "~1.1"
+            },
+            "conflict": {
+                "symfony/var-dumper": "<3.3"
             },
             "provide": {
                 "psr/cache-implementation": "1.0",
                 "psr/simple-cache-implementation": "1.0"
             },
             "require-dev": {
-                "cache/integration-tests": "^0.15.0",
+                "cache/integration-tests": "dev-master",
                 "doctrine/cache": "~1.6",
                 "doctrine/dbal": "~2.4",
                 "predis/predis": "~1.0"
             },
-            "suggest": {
-                "symfony/polyfill-apcu": "For using ApcuAdapter on HHVM"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -841,45 +1443,49 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2017-01-23 14:02:05"
+            "time": "2017-09-05 18:44:31"
         },
         {
             "name": "symfony/console",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "4dab8f5b2d6dbfb8ec808bd3d9d89dfa0eba5c42"
+                "reference": "78d1370ad8d26a3f1bc117a2ac3af419aaf5c37e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/4dab8f5b2d6dbfb8ec808bd3d9d89dfa0eba5c42",
-                "reference": "4dab8f5b2d6dbfb8ec808bd3d9d89dfa0eba5c42",
+                "url": "https://api.github.com/repos/symfony/console/zipball/78d1370ad8d26a3f1bc117a2ac3af419aaf5c37e",
+                "reference": "78d1370ad8d26a3f1bc117a2ac3af419aaf5c37e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "symfony/debug": "~2.8|~3.0",
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0|~4.0",
                 "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3",
+                "symfony/process": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/dependency-injection": "~2.8|~3.0",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
+                "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -906,7 +1512,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-23 22:46:36"
+            "time": "2017-09-03 15:31:40"
         },
         {
             "name": "symfony/debug",
@@ -914,28 +1520,28 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "55f724564dacda257840179a09e0edf3c9da7311"
+                "reference": "96bc445c20a66daacb138e5f4c53bf29a4b64c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/55f724564dacda257840179a09e0edf3c9da7311",
-                "reference": "55f724564dacda257840179a09e0edf3c9da7311",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/96bc445c20a66daacb138e5f4c53bf29a4b64c9c",
+                "reference": "96bc445c20a66daacb138e5f4c53bf29a4b64c9c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^7.1.3",
                 "psr/log": "~1.0"
             },
             "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+                "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0"
+                "symfony/http-kernel": "~3.4|~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -962,7 +1568,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-24 09:54:11"
+            "time": "2017-09-03 14:49:52"
         },
         {
             "name": "symfony/inflector",
@@ -970,21 +1576,21 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/inflector.git",
-                "reference": "e16e5588af1e9b1956554333e742e2da41f787ea"
+                "reference": "8740990f67ec9f89bfa116d11bad2990dd510ece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/inflector/zipball/e16e5588af1e9b1956554333e742e2da41f787ea",
-                "reference": "e16e5588af1e9b1956554333e742e2da41f787ea",
+                "url": "https://api.github.com/repos/symfony/inflector/zipball/8740990f67ec9f89bfa116d11bad2990dd510ece",
+                "reference": "8740990f67ec9f89bfa116d11bad2990dd510ece",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1019,29 +1625,29 @@
                 "symfony",
                 "words"
             ],
-            "time": "2017-01-02 20:33:09"
+            "time": "2017-08-31 20:46:21"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "3833c7ac7e3862ee1ba393c8d0be533bd90586d4"
+                "reference": "9e2ed813a4683bfa310a45d416b922fd7ede638c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/3833c7ac7e3862ee1ba393c8d0be533bd90586d4",
-                "reference": "3833c7ac7e3862ee1ba393c8d0be533bd90586d4",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/9e2ed813a4683bfa310a45d416b922fd7ede638c",
+                "reference": "9e2ed813a4683bfa310a45d416b922fd7ede638c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1073,7 +1679,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2017-01-02 20:33:09"
+            "time": "2017-08-03 09:34:20"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -1081,12 +1687,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "5d4474f447403c3348e37b70acc2b95475b7befa"
+                "reference": "cec32398a973a9bfe9d2f94f4b5d5e186b40b698"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/5d4474f447403c3348e37b70acc2b95475b7befa",
-                "reference": "5d4474f447403c3348e37b70acc2b95475b7befa",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/cec32398a973a9bfe9d2f94f4b5d5e186b40b698",
+                "reference": "cec32398a973a9bfe9d2f94f4b5d5e186b40b698",
                 "shasum": ""
             },
             "require": {
@@ -1095,7 +1701,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1126,7 +1732,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2017-07-05 15:09:33"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1134,12 +1740,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -1151,7 +1757,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1185,7 +1791,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2017-06-14 15:44:48"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -1193,12 +1799,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2"
+                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
-                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/b6482e68974486984f59449ecea1fbbb22ff840f",
+                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f",
                 "shasum": ""
             },
             "require": {
@@ -1208,7 +1814,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1244,29 +1850,29 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2017-06-14 15:44:48"
         },
         {
             "name": "symfony/property-access",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "f409701b2a905e09637cdb681042ad6a98805440"
+                "reference": "2740d63e7b3682832a7404bc23b44f651f953f35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/f409701b2a905e09637cdb681042ad6a98805440",
-                "reference": "f409701b2a905e09637cdb681042ad6a98805440",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/2740d63e7b3682832a7404bc23b44f651f953f35",
+                "reference": "2740d63e7b3682832a7404bc23b44f651f953f35",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "symfony/inflector": "~3.1",
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/inflector": "~3.1|~4.0",
                 "symfony/polyfill-php70": "~1.0"
             },
             "require-dev": {
-                "symfony/cache": "~3.1"
+                "symfony/cache": "~3.1|~4.0"
             },
             "suggest": {
                 "psr/cache-implementation": "To cache access methods."
@@ -1274,7 +1880,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1312,40 +1918,42 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2017-01-06 15:22:02"
+            "time": "2017-09-03 08:01:11"
         },
         {
             "name": "symfony/serializer",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "85db52d97031153d9fac44b3d63a4318d58899fa"
+                "reference": "ca9a7c8b8170246b8414bec95fa60d41b372afd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/85db52d97031153d9fac44b3d63a4318d58899fa",
-                "reference": "85db52d97031153d9fac44b3d63a4318d58899fa",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/ca9a7c8b8170246b8414bec95fa60d41b372afd9",
+                "reference": "ca9a7c8b8170246b8414bec95fa60d41b372afd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
+                "symfony/dependency-injection": "<3.2",
                 "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
                 "symfony/property-info": "<3.1",
-                "symfony/yaml": "<3.1"
+                "symfony/yaml": "<3.4"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.0",
-                "phpdocumentor/reflection-docblock": "~3.0",
-                "symfony/cache": "~3.1",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/http-foundation": "~2.8|~3.0",
-                "symfony/property-access": "~2.8|~3.0",
-                "symfony/property-info": "~3.1",
-                "symfony/yaml": "~3.1"
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.1|~4.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.2|~4.0",
+                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/property-access": "~2.8|~3.0|~4.0",
+                "symfony/property-info": "~3.1|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
@@ -1360,7 +1968,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1387,27 +1995,30 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-24 12:59:20"
+            "time": "2017-08-17 13:38:59"
         },
         {
             "name": "symfony/yaml",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7928849b226f065dae93ec0e8be3b829f73ba67b"
+                "reference": "bd9dcffc3eb2984afd4c534864f2802eccd3435a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7928849b226f065dae93ec0e8be3b829f73ba67b",
-                "reference": "7928849b226f065dae93ec0e8be3b829f73ba67b",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/bd9dcffc3eb2984afd4c534864f2802eccd3435a",
+                "reference": "bd9dcffc3eb2984afd4c534864f2802eccd3435a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~2.8|~3.0"
+                "symfony/console": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -1415,7 +2026,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1442,17 +2053,69 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 17:10:26"
+            "time": "2017-08-30 06:19:03"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "4a8bf11547e139e77b651365113fc12850c43d9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/4a8bf11547e139e77b651365113fc12850c43d9a",
+                "reference": "4a8bf11547e139e77b651365113fc12850c43d9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23 20:04:41"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "better-serializer/better-serializer": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6|^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
         env_file:
             - .env
         volumes:
-            - ~/.composer:/var/www/.composer
-            - .:/var/www/html
+            - ~/.composer:/var/www/.composer:cached
+            - .:/var/www/html:cached
     hhvm:
         <<: *php
         build: docker/hhvm

--- a/docker/php/config/apcu.ini
+++ b/docker/php/config/apcu.ini
@@ -1,0 +1,7 @@
+[apcu]
+extension="/usr/local/opt/php71-apcu/apcu.so"
+apc.enabled=1
+apc.shm_size=64M
+apc.ttl=7200
+apc.mmap_file_mask=/tmp/apc.XXXXXX
+apc.enable_cli=1

--- a/docker/php/config/apcu.ini
+++ b/docker/php/config/apcu.ini
@@ -1,7 +1,0 @@
-[apcu]
-extension="/usr/local/opt/php71-apcu/apcu.so"
-apc.enabled=1
-apc.shm_size=64M
-apc.ttl=7200
-apc.mmap_file_mask=/tmp/apc.XXXXXX
-apc.enable_cli=1

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,3 @@
+{
+  "bootstrap": "vendor/autoload.php"
+}

--- a/src/AbstractBenchmark.php
+++ b/src/AbstractBenchmark.php
@@ -12,8 +12,25 @@ use Ivory\Tests\Serializer\Benchmark\Model\Thread;
  */
 abstract class AbstractBenchmark implements BenchmarkInterface
 {
+
+    /**
+     * @const string
+     */
+    protected const NAME = 'override_me';
+
+    /**
+     *
+     */
     public function setUp()
     {
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::NAME;
     }
 
     /**

--- a/src/AbstractBenchmark.php
+++ b/src/AbstractBenchmark.php
@@ -2,10 +2,8 @@
 
 namespace Ivory\Tests\Serializer\Benchmark;
 
-use Ivory\Tests\Serializer\Benchmark\Model\Category;
-use Ivory\Tests\Serializer\Benchmark\Model\Comment;
 use Ivory\Tests\Serializer\Benchmark\Model\Forum;
-use Ivory\Tests\Serializer\Benchmark\Model\Thread;
+use Ivory\Tests\Serializer\Benchmark\Runner\DataGenerator;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -17,6 +15,19 @@ abstract class AbstractBenchmark implements BenchmarkInterface
      * @const string
      */
     protected const NAME = 'override_me';
+
+    /**
+     * @var DataGenerator
+     */
+    private $dataGenerator;
+
+    /**
+     * AbstractBenchmark constructor.
+     */
+    public function __construct()
+    {
+        $this->dataGenerator = new DataGenerator();
+    }
 
     /**
      *
@@ -47,59 +58,8 @@ abstract class AbstractBenchmark implements BenchmarkInterface
      *
      * @return Forum
      */
-    protected function getData($horizontalComplexity = 1, $verticalComplexity = 1)
+    protected function getData(int $horizontalComplexity = 1, int $verticalComplexity = 1): Forum
     {
-        $forum = new Forum(1, 'Great name!');
-        $forum->setCategory($this->createCategory($verticalComplexity));
-
-        for ($i = 0; $i < $horizontalComplexity * 2; ++$i) {
-            $forum->addThread($this->createThread($i, $horizontalComplexity));
-        }
-
-        return $forum;
-    }
-
-    /**
-     * @param int $verticalComplexity
-     *
-     * @return Category
-     */
-    private function createCategory($verticalComplexity = 1)
-    {
-        $original = $category = new Category(1);
-
-        for ($i = 0; $i < $verticalComplexity * 2; ++$i) {
-            $category->setParent($parent = new Category($i + 1));
-            $category = $parent;
-        }
-
-        return $original;
-    }
-
-    /**
-     * @param int $index
-     * @param int $horizontalComplexity
-     *
-     * @return Thread
-     */
-    private function createThread($index, $horizontalComplexity = 1)
-    {
-        $thread = new Thread($index, 'Great thread '.$index.'!', 'Great description '.$index, $index / 100);
-
-        for ($i = 0; $i < $horizontalComplexity * 5; ++$i) {
-            $thread->addComment($this->createComment($index * $i + $i));
-        }
-
-        return $thread;
-    }
-
-    /**
-     * @param int $index
-     *
-     * @return Comment
-     */
-    private function createComment($index)
-    {
-        return new Comment($index, 'Great comment '.$index.'!');
+        return $this->dataGenerator->getData($horizontalComplexity, $verticalComplexity);
     }
 }

--- a/src/BenchmarkInterface.php
+++ b/src/BenchmarkInterface.php
@@ -10,6 +10,11 @@ interface BenchmarkInterface
     public function setUp();
 
     /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
      * @param int $horizontalComplexity
      * @param int $verticalComplexity
      */

--- a/src/BsBenchmark.php
+++ b/src/BsBenchmark.php
@@ -32,7 +32,7 @@ class BsBenchmark extends AbstractBenchmark
         if (extension_loaded('apcu') && ini_get('apc.enabled')) {
             $builder->enableApcuCache();
         } else {
-            $builder->setCacheDir(dirname(__DIR__, 2) . '/cache/better-serializer');
+            $builder->enableFilesystemCache(dirname(__DIR__, 1) . '/cache/better-serializer');
         }
 
         $this->serializer = $builder->createSerializer();

--- a/src/BsBenchmark.php
+++ b/src/BsBenchmark.php
@@ -2,35 +2,40 @@
 
 namespace Ivory\Tests\Serializer\Benchmark;
 
+use BetterSerializer\Builder;
 use BetterSerializer\Common\SerializationType;
 use BetterSerializer\Serializer;
-use Pimple\Container;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
 class BsBenchmark extends AbstractBenchmark
 {
+
     /**
-     * @var Container
+     * @const string
      */
-    private static $container;
+    protected const NAME = 'BetterSerializer';
 
     /**
      * @var Serializer
      */
-    private static $serializer;
+    private $serializer;
 
     /**
      * {@inheritdoc}
      */
     public function setUp()
     {
-        self::$container = require dirname(__DIR__) . '/vendor/better-serializer/better-serializer/dev/di.pimple.php';
-        self::$serializer = self::$container->offsetGet(Serializer::class);
-//        $this->serializer = SerializerBuilder::create()
-//            ->setCacheDir(__DIR__.'/../cache/Jms')
-//            ->build();
+        $builder = new Builder();
+
+        if (extension_loaded('apcu') && ini_get('apc.enabled')) {
+            $builder->enableApcuCache();
+        } else {
+            $builder->setCacheDir(dirname(__DIR__, 2) . '/cache/better-serializer');
+        }
+
+        $this->serializer = $builder->createSerializer();
     }
 
     /**
@@ -38,7 +43,7 @@ class BsBenchmark extends AbstractBenchmark
      */
     public function execute($horizontalComplexity = 1, $verticalComplexity = 1)
     {
-        return self::$serializer->serialize(
+        return $this->serializer->serialize(
             $this->getData($horizontalComplexity, $verticalComplexity),
             SerializationType::byValue($this->getFormat())
         );

--- a/src/BsBenchmark.php
+++ b/src/BsBenchmark.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ivory\Tests\Serializer\Benchmark;
+
+use BetterSerializer\Common\SerializationType;
+use BetterSerializer\Serializer;
+use Pimple\Container;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class BsBenchmark extends AbstractBenchmark
+{
+    /**
+     * @var Container
+     */
+    private static $container;
+
+    /**
+     * @var Serializer
+     */
+    private static $serializer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        self::$container = require dirname(__DIR__) . '/vendor/better-serializer/better-serializer/dev/di.pimple.php';
+        self::$serializer = self::$container->offsetGet(Serializer::class);
+//        $this->serializer = SerializerBuilder::create()
+//            ->setCacheDir(__DIR__.'/../cache/Jms')
+//            ->build();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($horizontalComplexity = 1, $verticalComplexity = 1)
+    {
+        return self::$serializer->serialize(
+            $this->getData($horizontalComplexity, $verticalComplexity),
+            SerializationType::byValue($this->getFormat())
+        );
+    }
+}

--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -2,6 +2,7 @@
 
 namespace Ivory\Tests\Serializer\Benchmark\Command;
 
+use Ivory\Tests\Serializer\Benchmark\BsBenchmark;
 use Ivory\Tests\Serializer\Benchmark\IvoryBenchmark;
 use Ivory\Tests\Serializer\Benchmark\JmsBenchmark;
 use Ivory\Tests\Serializer\Benchmark\Result\BenchmarkResultInterface;
@@ -55,6 +56,7 @@ class BenchmarkCommand extends Command
             new SymfonyObjectNormalizerBenchmark(),
             new SymfonyGetSetNormalizerBenchmark(),
             new JmsBenchmark(),
+            new BsBenchmark(),
         ];
 
         $iteration = $input->getOption('iteration');

--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -6,10 +6,12 @@ use Ivory\Tests\Serializer\Benchmark\BsBenchmark;
 use Ivory\Tests\Serializer\Benchmark\IvoryBenchmark;
 use Ivory\Tests\Serializer\Benchmark\JmsBenchmark;
 use Ivory\Tests\Serializer\Benchmark\Result\BenchmarkResultInterface;
+use Ivory\Tests\Serializer\Benchmark\Result\ResultsAggregate;
 use Ivory\Tests\Serializer\Benchmark\Runner\BenchmarkRunner;
 use Ivory\Tests\Serializer\Benchmark\SymfonyGetSetNormalizerBenchmark;
 use Ivory\Tests\Serializer\Benchmark\SymfonyObjectNormalizerBenchmark;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -53,8 +55,8 @@ class BenchmarkCommand extends Command
     {
         $benchmarks = [
             new IvoryBenchmark(),
-            new SymfonyObjectNormalizerBenchmark(),
-            new SymfonyGetSetNormalizerBenchmark(),
+//            new SymfonyObjectNormalizerBenchmark(),
+//            new SymfonyGetSetNormalizerBenchmark(),
             new JmsBenchmark(),
             new BsBenchmark(),
         ];
@@ -63,20 +65,20 @@ class BenchmarkCommand extends Command
         $horizontalComplexity = $input->getOption('horizontal-complexity');
         $verticalComplexity = $input->getOption('vertical-complexity');
 
-        foreach ($benchmarks as $benchmark) {
-            $this->output(
-                $this->runner->run($benchmark, $iteration, $horizontalComplexity, $verticalComplexity),
-                $output
-            );
-        }
-    }
+        $results = new ResultsAggregate();
 
-    /**
-     * @param BenchmarkResultInterface $result
-     * @param OutputInterface          $output
-     */
-    private function output(BenchmarkResultInterface $result, OutputInterface $output)
-    {
-        $output->writeln(get_class($result->getBenchmark()).' | '.$result->getTime());
+        foreach ($benchmarks as $benchmark) {
+            $output->writeln($benchmark->getName() . ': Done!');
+            $results->addResult($this->runner->run($benchmark, $iteration, $horizontalComplexity, $verticalComplexity));
+        }
+
+        $output->writeln('');
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Serializer', 'Duration (sec)', 'Factor'])
+            ->setRows($results->getResultRows())
+        ;
+        $table->render();
     }
 }

--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -68,8 +68,8 @@ class BenchmarkCommand extends Command
         $results = new ResultsAggregate();
 
         foreach ($benchmarks as $benchmark) {
-            $output->writeln($benchmark->getName() . ': Done!');
             $results->addResult($this->runner->run($benchmark, $iteration, $horizontalComplexity, $verticalComplexity));
+            $output->writeln($benchmark->getName() . ': Done!');
         }
 
         $output->writeln('');

--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -45,7 +46,8 @@ class BenchmarkCommand extends Command
             ->setName('benchmark')
             ->addOption('iteration', 'i', InputArgument::OPTIONAL, 'Number of iteration(s)', 1)
             ->addOption('horizontal-complexity', 'hc', InputArgument::OPTIONAL, 'Horizontal data complexity', 1)
-            ->addOption('vertical-complexity', 'vc', InputArgument::OPTIONAL, 'Vertical data complexity', 1);
+            ->addOption('vertical-complexity', 'vc', InputArgument::OPTIONAL, 'Vertical data complexity', 1)
+            ->addOption('with-symfony-serializer', 'wss', InputOption::VALUE_NONE, 'Also run with Symfony serializer');
     }
 
     /**
@@ -55,11 +57,16 @@ class BenchmarkCommand extends Command
     {
         $benchmarks = [
             new IvoryBenchmark(),
-//            new SymfonyObjectNormalizerBenchmark(),
-//            new SymfonyGetSetNormalizerBenchmark(),
             new JmsBenchmark(),
             new BsBenchmark(),
         ];
+
+        $withSymfony = $input->getOption('with-symfony-serializer');
+
+        if ($withSymfony) {
+            $benchmarks[] = new SymfonyObjectNormalizerBenchmark();
+            $benchmarks[] = new SymfonyGetSetNormalizerBenchmark();
+        }
 
         $iteration = $input->getOption('iteration');
         $horizontalComplexity = $input->getOption('horizontal-complexity');

--- a/src/IvoryBenchmark.php
+++ b/src/IvoryBenchmark.php
@@ -16,6 +16,12 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
  */
 class IvoryBenchmark extends AbstractBenchmark
 {
+
+    /**
+     * @const string
+     */
+    protected const NAME = 'Ivory';
+
     /**
      * @var Serializer
      */

--- a/src/JmsBenchmark.php
+++ b/src/JmsBenchmark.php
@@ -10,6 +10,12 @@ use JMS\Serializer\SerializerBuilder;
  */
 class JmsBenchmark extends AbstractBenchmark
 {
+
+    /**
+     * @const string
+     */
+    protected const NAME = 'JMS';
+
     /**
      * @var Serializer
      */

--- a/src/Result/BenchmarkResult.php
+++ b/src/Result/BenchmarkResult.php
@@ -10,9 +10,9 @@ use Ivory\Tests\Serializer\Benchmark\BenchmarkInterface;
 class BenchmarkResult implements BenchmarkResultInterface
 {
     /**
-     * @var BenchmarkInterface
+     * @var string
      */
-    private $benchmark;
+    private $name;
 
     /**
      * @var int
@@ -20,27 +20,27 @@ class BenchmarkResult implements BenchmarkResultInterface
     private $time;
 
     /**
-     * @param BenchmarkInterface $benchmark
+     * @param string $name
      * @param int                $time
      */
-    public function __construct(BenchmarkInterface $benchmark, $time)
+    public function __construct(string $name, $time)
     {
-        $this->benchmark = $benchmark;
+        $this->name = $name;
         $this->time = $time;
     }
 
     /**
-     * @return BenchmarkInterface
+     * @return string
      */
-    public function getBenchmark()
+    public function getName(): string
     {
-        return $this->benchmark;
+        return $this->name;
     }
 
     /**
-     * {@inheritdoc}
+     * @return float
      */
-    public function getTime()
+    public function getTime(): float
     {
         return $this->time;
     }

--- a/src/Result/BenchmarkResultInterface.php
+++ b/src/Result/BenchmarkResultInterface.php
@@ -10,12 +10,12 @@ use Ivory\Tests\Serializer\Benchmark\BenchmarkInterface;
 interface BenchmarkResultInterface
 {
     /**
-     * @return BenchmarkInterface
+     * @return string
      */
-    public function getBenchmark();
+    public function getName(): string;
 
     /**
-     * @return int
+     * @return float
      */
-    public function getTime();
+    public function getTime(): float;
 }

--- a/src/Result/BenchmarkResults.php
+++ b/src/Result/BenchmarkResults.php
@@ -28,23 +28,23 @@ class BenchmarkResults implements BenchmarkResultInterface
     /**
      * @return BenchmarkResultInterface[]
      */
-    public function getResults()
+    public function getResults(): array
     {
         return $this->results;
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
-    public function getBenchmark()
+    public function getName(): string
     {
-        return reset($this->results)->getBenchmark();
+        return reset($this->results)->getName();
     }
 
     /**
-     * {@inheritdoc}
+     * @return float
      */
-    public function getTime()
+    public function getTime(): float
     {
         if ($this->time !== null) {
             return $this->time;

--- a/src/Result/ResultsAggregate.php
+++ b/src/Result/ResultsAggregate.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace Ivory\Tests\Serializer\Benchmark\Result;
+
+/**
+ * Class ResultsAggregate
+ * @author mfris
+ * @package Ivory\Tests\Serializer\Benchmark\Result
+ */
+final class ResultsAggregate
+{
+
+    /**
+     * @var BenchmarkResultInterface[]
+     */
+    private $results = [];
+
+    /**
+     * @param BenchmarkResultInterface $result
+     */
+    public function addResult(BenchmarkResultInterface $result): void
+    {
+        $this->results[] = $result;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResultRows(): array
+    {
+        usort($this->results, function(BenchmarkResultInterface $a, BenchmarkResultInterface $b) {
+            return $a->getTime() <=> $b->getTime();
+        });
+
+        $fastestTime = $this->results[0]->getTime();
+
+        $rows = [];
+
+        foreach ($this->results as $result) {
+            $rows[] = [
+                $result->getName(),
+                sprintf('%.6fs', $result->getTime()),
+                sprintf('%.2fx', $result->getTime() / $fastestTime),
+            ];
+        }
+
+        return $rows;
+    }
+}

--- a/src/Runner/BenchmarkRunner.php
+++ b/src/Runner/BenchmarkRunner.php
@@ -55,6 +55,6 @@ class BenchmarkRunner
         $benchmark->execute($horizontalComplexity, $verticalComplexity);
         $finishTime = microtime(true);
 
-        return new BenchmarkResult($benchmark, $finishTime - $startTime);
+        return new BenchmarkResult($benchmark->getName(), $finishTime - $startTime);
     }
 }

--- a/src/Runner/DataGenerator.php
+++ b/src/Runner/DataGenerator.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace Ivory\Tests\Serializer\Benchmark\Runner;
+
+use Ivory\Tests\Serializer\Benchmark\Model\Category;
+use Ivory\Tests\Serializer\Benchmark\Model\Comment;
+use Ivory\Tests\Serializer\Benchmark\Model\Forum;
+use Ivory\Tests\Serializer\Benchmark\Model\Thread;
+
+/**
+ * Class DataGenerator
+ * @author mfris
+ * @package Ivory\Tests\Serializer\Benchmark\Runner
+ */
+final class DataGenerator
+{
+
+    /**
+     * @param int $horizontalComplexity
+     * @param int $verticalComplexity
+     *
+     * @return Forum
+     */
+    public function getData(int $horizontalComplexity = 1, int $verticalComplexity = 1): Forum
+    {
+        $forum = new Forum(1, 'Great name!');
+        $forum->setCategory($this->createCategory($verticalComplexity));
+
+        for ($i = 0; $i < $horizontalComplexity * 2; ++$i) {
+            $forum->addThread($this->createThread($i, $horizontalComplexity));
+        }
+
+        return $forum;
+    }
+
+    /**
+     * @param int $verticalComplexity
+     *
+     * @return Category
+     */
+    private function createCategory(int $verticalComplexity = 1): Category
+    {
+        $original = $category = new Category(1);
+
+        for ($i = 0; $i < $verticalComplexity * 2; ++$i) {
+            $category->setParent($parent = new Category($i + 1));
+            $category = $parent;
+        }
+
+        return $original;
+    }
+
+    /**
+     * @param int $index
+     * @param int $horizontalComplexity
+     *
+     * @return Thread
+     */
+    private function createThread($index, $horizontalComplexity = 1): Thread
+    {
+        $thread = new Thread($index, 'Great thread '.$index.'!', 'Great description '.$index, $index / 100);
+
+        for ($i = 0; $i < $horizontalComplexity * 5; ++$i) {
+            $thread->addComment($this->createComment($index * $i + $i));
+        }
+
+        return $thread;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return Comment
+     */
+    private function createComment($index): Comment
+    {
+        return new Comment($index, 'Great comment '.$index.'!');
+    }
+}

--- a/src/SerializerBenchmarks/AbstractBench.php
+++ b/src/SerializerBenchmarks/AbstractBench.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace SerializerBenchmarks;
+
+use Ivory\Tests\Serializer\Benchmark\Runner\DataGenerator;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+
+/**
+ * Class AbstractBench
+ * @author mfris
+ * @package Benchmarks
+ * @BeforeMethods({"init"})
+ */
+abstract class AbstractBench
+{
+
+    /**
+     * @var DataGenerator
+     */
+    private $dataGenerator;
+
+    /**
+     * @var mixed
+     */
+    private $data;
+
+    /**
+     * AbstractBench constructor.
+     */
+    public function __construct()
+    {
+        $this->dataGenerator = new DataGenerator();
+    }
+
+    /**
+     * @return array
+     */
+    public function provideData(): array
+    {
+        return [
+            [
+                'horizontal' => 1,
+                'vertical' => 1,
+            ],
+            [
+                'horizontal' => 2,
+                'vertical' => 2,
+            ],
+            [
+                'horizontal' => 10,
+                'vertical' => 10,
+            ],
+            [
+                'horizontal' => 20,
+                'vertical' => 20,
+            ],
+            [
+                'horizontal' => 50,
+                'vertical' => 50,
+            ],
+            [
+                'horizontal' => 100,
+                'vertical' => 100,
+            ],
+            [
+                'horizontal' => 100,
+                'vertical' => 200,
+            ],
+        ];
+    }
+
+    /**
+     *
+     */
+    abstract public function init(): void;
+
+    /**
+     * @param array $params
+     * @ParamProviders({"provideData"})
+     */
+    abstract public function bench(array $params): void;
+
+    /**
+     * @return DataGenerator
+     */
+    protected function getDataGenerator(): DataGenerator
+    {
+        return $this->dataGenerator;
+    }
+
+    /**
+     * @param array $params
+     * @return mixed
+     */
+    protected function getData(array $params)
+    {
+        if ($this->data === null) {
+            $this->data = $this->dataGenerator->getData($params['horizontal'], $params['vertical']);
+        }
+
+        return $this->data;
+    }
+}

--- a/src/SerializerBenchmarks/BetterSerializerBench.php
+++ b/src/SerializerBenchmarks/BetterSerializerBench.php
@@ -39,7 +39,7 @@ final class BetterSerializerBench extends AbstractBench
         if (extension_loaded('apcu') && ini_get('apc.enabled')) {
             $builder->enableApcuCache();
         } else {
-            $builder->setCacheDir(dirname(__DIR__, 2) . '/cache/better-serializer');
+            $builder->enableFilesystemCache(dirname(__DIR__, 2) . '/cache/better-serializer');
         }
 
         $this->serializer = $builder->createSerializer();

--- a/src/SerializerBenchmarks/BetterSerializerBench.php
+++ b/src/SerializerBenchmarks/BetterSerializerBench.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace SerializerBenchmarks;
+
+use BetterSerializer\Builder;
+use BetterSerializer\Common\SerializationType;
+use BetterSerializer\Serializer;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Pimple\Exception\UnknownIdentifierException;
+use LogicException;
+use ReflectionException;
+use RuntimeException;
+
+/**
+ * Class BetterSerializerBench
+ * @author mfris
+ */
+final class BetterSerializerBench extends AbstractBench
+{
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     * @throws RuntimeException|UnknownIdentifierException
+     */
+    public function init(): void
+    {
+        $builder = new Builder();
+
+        if (extension_loaded('apcu') && ini_get('apc.enabled')) {
+            $builder->enableApcuCache();
+        } else {
+            $builder->setCacheDir(dirname(__DIR__, 2) . '/cache/better-serializer');
+        }
+
+        $this->serializer = $builder->createSerializer();
+    }
+
+    /**
+     * @param array $params
+     * @ParamProviders({"provideData"})
+     * @Warmup(1)
+     * @throws LogicException|ReflectionException|RuntimeException
+     */
+    public function bench(array $params): void
+    {
+        $this->serializer->serialize($this->getData($params), SerializationType::JSON());
+    }
+}

--- a/src/SerializerBenchmarks/IvorySerializerBench.php
+++ b/src/SerializerBenchmarks/IvorySerializerBench.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace SerializerBenchmarks;
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Ivory\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Ivory\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Ivory\Serializer\Navigator\Navigator;
+use Ivory\Serializer\Registry\TypeRegistry;
+use Ivory\Serializer\Serializer;
+use Ivory\Serializer\Type\ObjectType;
+use Ivory\Serializer\Type\Type;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+
+/**
+ * Class JmsSerializerBench
+ * @author mfris
+ * @package SerializerBenchmarks
+ */
+final class IvorySerializerBench extends AbstractBench
+{
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     *
+     */
+    public function init(): void
+    {
+        $loader = require __DIR__.'/../../vendor/autoload.php';
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+        $classMetadataFactory = new CacheClassMetadataFactory(
+            ClassMetadataFactory::create(),
+            new ApcuAdapter('IvoryMetadata')
+        );
+
+        $typeRegistry = TypeRegistry::create([
+            Type::OBJECT => new ObjectType($classMetadataFactory),
+        ]);
+
+        $this->serializer = new Serializer(new Navigator($typeRegistry));
+    }
+
+    /**
+     * @param array $params
+     * @ParamProviders({"provideData"})
+     * @Warmup(1)
+     */
+    public function bench(array $params): void
+    {
+        $this->serializer->serialize($this->getData($params), 'json');
+    }
+}

--- a/src/SerializerBenchmarks/JmsSerializerBench.php
+++ b/src/SerializerBenchmarks/JmsSerializerBench.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace SerializerBenchmarks;
+
+use JMS\Serializer\Serializer;
+use JMS\Serializer\SerializerBuilder;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * Class JmsSerializerBench
+ * @author mfris
+ * @package SerializerBenchmarks
+ */
+final class JmsSerializerBench extends AbstractBench
+{
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     *
+     */
+    public function init(): void
+    {
+        $this->serializer = SerializerBuilder::create()
+            ->setCacheDir(__DIR__.'/../../cache/Jms')
+            ->build();
+    }
+
+    /**
+     * @param array $params
+     * @ParamProviders({"provideData"})
+     * @Warmup(1)
+     */
+    public function bench(array $params): void
+    {
+        $this->serializer->serialize($this->getData($params), 'json');
+    }
+}

--- a/src/SerializerBenchmarks/SymfonyGsNormSerializerBench.php
+++ b/src/SerializerBenchmarks/SymfonyGsNormSerializerBench.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace SerializerBenchmarks;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use PhpBench\Serializer\XmlEncoder;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Class JmsSerializerBench
+ * @author mfris
+ * @package SerializerBenchmarks
+ */
+final class SymfonyGsNormSerializerBench extends AbstractBench
+{
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     *
+     */
+    public function init(): void
+    {
+        $loader = require __DIR__.'/../../vendor/autoload.php';
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+        $classMetadataFactory = new CacheClassMetadataFactory(
+            new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())),
+            new ApcuAdapter('SymfonyMetadata')
+        );
+
+        $this->serializer = new Serializer(
+            [new GetSetMethodNormalizer($classMetadataFactory)],
+            [new JsonEncoder(), new XmlEncoder(), new YamlEncoder()]
+        );
+    }
+
+    /**
+     * @param array $params
+     * @ParamProviders({"provideData"})
+     * @Warmup(1)
+     */
+    public function bench(array $params): void
+    {
+        $this->serializer->serialize($this->getData($params), 'json');
+    }
+
+    /**
+     * @return array
+     */
+    public function provideData(): array
+    {
+        return [
+            [
+                'vertical' => 1,
+                'horizontal' => 1,
+            ],
+            [
+                'vertical' => 2,
+                'horizontal' => 2,
+            ],
+        ];
+    }
+}

--- a/src/SerializerBenchmarks/SymfonyObjNormSerializerBench.php
+++ b/src/SerializerBenchmarks/SymfonyObjNormSerializerBench.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @author Martin Fris <rasta@lj.sk>
+ */
+
+namespace SerializerBenchmarks;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use PhpBench\Benchmark\Metadata\Annotations\ParamProviders;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use PhpBench\Serializer\XmlEncoder;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Class JmsSerializerBench
+ * @author mfris
+ * @package SerializerBenchmarks
+ */
+final class SymfonyObjNormSerializerBench extends AbstractBench
+{
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     *
+     */
+    public function init(): void
+    {
+        $loader = require __DIR__.'/../../vendor/autoload.php';
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+        $classMetadataFactory = new CacheClassMetadataFactory(
+            new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())),
+            new ApcuAdapter('SymfonyMetadata')
+        );
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->setCacheItemPool(new ApcuAdapter('SymfonyPropertyAccessor'))
+            ->getPropertyAccessor();
+
+        $this->serializer = new Serializer(
+            [new ObjectNormalizer($classMetadataFactory, null, $propertyAccessor)],
+            [new JsonEncoder(), new XmlEncoder(), new YamlEncoder()]
+        );
+    }
+
+    /**
+     * @param array $params
+     * @ParamProviders({"provideData"})
+     * @Warmup(1)
+     */
+    public function bench(array $params): void
+    {
+        $this->serializer->serialize($this->getData($params), 'json');
+    }
+
+    /**
+     * @return array
+     */
+    public function provideData(): array
+    {
+        return [
+            [
+                'vertical' => 1,
+                'horizontal' => 1,
+            ],
+            [
+                'vertical' => 2,
+                'horizontal' => 2,
+            ],
+        ];
+    }
+}

--- a/src/SymfonyGetSetNormalizerBenchmark.php
+++ b/src/SymfonyGetSetNormalizerBenchmark.php
@@ -18,6 +18,12 @@ use Symfony\Component\Serializer\Serializer;
  */
 class SymfonyGetSetNormalizerBenchmark extends AbstractBenchmark
 {
+
+    /**
+     * @const string
+     */
+    protected const NAME = 'Symfony - GetNormalizer';
+
     /**
      * @var Serializer
      */

--- a/src/SymfonyGetSetNormalizerBenchmark.php
+++ b/src/SymfonyGetSetNormalizerBenchmark.php
@@ -31,6 +31,9 @@ class SymfonyGetSetNormalizerBenchmark extends AbstractBenchmark
 
     /**
      * {@inheritdoc}
+     * @throws \Doctrine\Common\Annotations\AnnotationException
+     * @throws \InvalidArgumentException
+     * @throws \Symfony\Component\Serializer\Exception\RuntimeException
      */
     public function setUp()
     {

--- a/src/SymfonyObjectNormalizerBenchmark.php
+++ b/src/SymfonyObjectNormalizerBenchmark.php
@@ -19,6 +19,12 @@ use Symfony\Component\Serializer\Serializer;
  */
 class SymfonyObjectNormalizerBenchmark extends AbstractBenchmark
 {
+
+    /**
+     * @const string
+     */
+    protected const NAME = 'Symfony - ObjectNormalizer';
+
     /**
      * @var Serializer
      */

--- a/src/SymfonyObjectNormalizerBenchmark.php
+++ b/src/SymfonyObjectNormalizerBenchmark.php
@@ -32,6 +32,9 @@ class SymfonyObjectNormalizerBenchmark extends AbstractBenchmark
 
     /**
      * {@inheritdoc}
+     * @throws \Doctrine\Common\Annotations\AnnotationException
+     * @throws \InvalidArgumentException
+     * @throws \Symfony\Component\Serializer\Exception\RuntimeException
      */
     public function setUp()
     {
@@ -52,6 +55,7 @@ class SymfonyObjectNormalizerBenchmark extends AbstractBenchmark
 
     /**
      * {@inheritdoc}
+     * @throws
      */
     public function execute($horizontalComplexity = 1, $verticalComplexity = 1)
     {


### PR DESCRIPTION
Hi, I created my own serializer which seems to be 4-5x faster than JMS and Ivory (using json serialization) ... since there is quite a big difference between the mentioned 3 libs and symfony serializer,  I disabled the symfony serializer, because it was 100-300x slower then my own serializer and it was quite a pain to wait for the benchmark results.

Is there any other thing I should do before merge? What do you say about these changes?