### PR TITLE
DateTimeNormalizer should be registered for like for like comparison

### DIFF
--- a/src/SymfonyGetSetNormalizerBenchmark.php
+++ b/src/SymfonyGetSetNormalizerBenchmark.php
@@ -10,6 +10,7 @@ use Symfony\Component\Serializer\Encoder\YamlEncoder;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
@@ -34,7 +35,7 @@ class SymfonyGetSetNormalizerBenchmark extends AbstractBenchmark
         );
 
         $this->serializer = new Serializer(
-            [new GetSetMethodNormalizer($classMetadataFactory)],
+            [new DateTimeNormalizer(), new GetSetMethodNormalizer($classMetadataFactory)],
             [new JsonEncoder(), new XmlEncoder(), new YamlEncoder()]
         );
     }

--- a/src/SymfonyObjectNormalizerBenchmark.php
+++ b/src/SymfonyObjectNormalizerBenchmark.php
@@ -11,6 +11,7 @@ use Symfony\Component\Serializer\Encoder\YamlEncoder;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
@@ -39,7 +40,7 @@ class SymfonyObjectNormalizerBenchmark extends AbstractBenchmark
             ->getPropertyAccessor();
 
         $this->serializer = new Serializer(
-            [new ObjectNormalizer($classMetadataFactory, null, $propertyAccessor)],
+            [new DateTimeNormalizer(), new ObjectNormalizer($classMetadataFactory, null, $propertyAccessor)],
             [new JsonEncoder(), new XmlEncoder(), new YamlEncoder()]
         );
     }


### PR DESCRIPTION
The symfony serializers weren't registering the `DateTimeNormalizer`. Ivory and JMS have them built in, so we need to manually register it for symfony for a fair comparison.

This improves the symfony bencharmk quite a bit.